### PR TITLE
Re-enable numeraires in onboarding

### DIFF
--- a/apps/extension/src/hooks/numeraires-query.ts
+++ b/apps/extension/src/hooks/numeraires-query.ts
@@ -3,26 +3,25 @@ import { ChainRegistryClient } from '@penumbra-labs/registry';
 import { useMemo } from 'react';
 
 export const useNumeraires = (chainId?: string) => {
-  const { data, isLoading, error, isError } = useQuery({
+  const { data, isLoading, isError } = useQuery({
     queryKey: ['registry', chainId],
     queryFn: async () => {
       const registryClient = new ChainRegistryClient();
       return registryClient.remote.get(chainId!);
     },
+    retry: 1,
+    retryDelay: 0,
     staleTime: Infinity,
     enabled: Boolean(chainId),
   });
 
   const numeraires = useMemo(() => {
-    if (!chainId) {
-      if (isError) {
-        console.error(`Could not load numeraires for chainId: ${chainId}`);
-      }
-      return [];
+    if (isError) {
+      console.error(`Could not load numeraires for chainId: ${chainId}`);
     }
 
     return data?.numeraires.map(n => data.getMetadata(n)) ?? [];
   }, [data, chainId, isError]);
 
-  return { numeraires, isLoading, error };
+  return { numeraires, isLoading, isError };
 };

--- a/apps/extension/src/routes/page/onboarding/set-numeraire.tsx
+++ b/apps/extension/src/routes/page/onboarding/set-numeraire.tsx
@@ -3,9 +3,11 @@ import { FadeTransition } from '@repo/ui/components/ui/fade-transition';
 import { usePageNav } from '../../../utils/navigate';
 import { PagePath } from '../paths';
 import { NumeraireForm } from '../../../shared/components/numeraires-form';
+import { useStore } from '../../../state';
 
 export const SetNumerairesPage = () => {
   const navigate = usePageNav();
+  const chainId = useStore(state => state.network.chainId);
 
   const onSuccess = (): void => {
     navigate(PagePath.ONBOARDING_SUCCESS);
@@ -22,7 +24,7 @@ export const SetNumerairesPage = () => {
           </CardDescription>
         </CardHeader>
         <div className='mt-6'>
-          <NumeraireForm isOnboarding onSuccess={onSuccess} />
+          <NumeraireForm isOnboarding onSuccess={onSuccess} chainId={chainId} />
         </div>
       </Card>
     </FadeTransition>

--- a/apps/extension/src/routes/popup/settings/settings-numeraires.tsx
+++ b/apps/extension/src/routes/popup/settings/settings-numeraires.tsx
@@ -3,16 +3,18 @@ import { NumerairesGradientIcon } from '../../../icons/numeraires-gradient';
 import { usePopupNav } from '../../../utils/navigate';
 import { PopupPath } from '../paths';
 import { NumeraireForm } from '../../../shared/components/numeraires-form';
+import { useChainIdQuery } from '../../../hooks/chain-id';
 
 export const SettingsNumeraires = () => {
   const navigate = usePopupNav();
+  const { chainId } = useChainIdQuery();
 
   const onSuccess = () => {
     navigate(PopupPath.INDEX);
   };
   return (
     <SettingsScreen title='Price denominations' IconComponent={NumerairesGradientIcon}>
-      <NumeraireForm onSuccess={onSuccess} />
+      <NumeraireForm onSuccess={onSuccess} chainId={chainId} />
     </SettingsScreen>
   );
 };


### PR DESCRIPTION
Bug fix. Now that a numeraire is [available in the registry](https://github.com/prax-wallet/registry/pull/94), Prax should be recognizing it and during onboarding, giving the users an opportunity to use it. This will enable usdc prices in minifront.

However, due to a react useEffect loading bug, it is skipping this step. This PR fixes that.


<img width="465" alt="Screenshot 2024-09-24 at 9 45 29 PM" src="https://github.com/user-attachments/assets/cba20999-35c7-4060-ba01-2c63dbdfc2ae">
