### PR TITLE
fix: allow http for production prax too

### DIFF
--- a/apps/extension/src/senders/validate.ts
+++ b/apps/extension/src/senders/validate.ts
@@ -35,12 +35,7 @@ export const assertValidSender = (sender?: chrome.runtime.MessageSender) => {
     throw new Error('Sender origin is invalid');
   }
 
-  if (
-    !(
-      parsedOrigin.protocol in ValidProtocol ||
-      (globalThis.__DEV__ && isHttpLocalhost(parsedOrigin))
-    )
-  ) {
+  if (!(parsedOrigin.protocol in ValidProtocol || isHttpLocalhost(parsedOrigin))) {
     throw new Error(`Sender protocol is not ${Object.values(ValidProtocol).join(',')}`);
   }
 


### PR DESCRIPTION
Allows `http` apps to connect to production-built Prax 