### PR TITLE
fix: beta extension bundle

### DIFF
--- a/.github/workflows/extension-upload.yml
+++ b/.github/workflows/extension-upload.yml
@@ -41,7 +41,7 @@ jobs:
 
       # Outputs beta.zip and prod.zip
       - name: Zip extension versions
-        run: pnpm tsx apps/extension/src/utils/zip-extension.ts
+        run: pnpm zip
 
       - name: Upload beta version
         uses: penumbra-zone/chrome-extension-upload@v1

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ out/
 build
 dist/
 dist
+beta-dist
 dist-ssr
 *.local
 

--- a/apps/extension/.env
+++ b/apps/extension/.env
@@ -1,1 +1,0 @@
-PRAX=lkpmkhpnhknhmibgnmmhdhgdilepfghe

--- a/apps/extension/.env.beta
+++ b/apps/extension/.env.beta
@@ -1,0 +1,1 @@
+PRAX=ejpfkiblcablembkdhcofhokccbbppnc

--- a/apps/extension/.env.beta
+++ b/apps/extension/.env.beta
@@ -1,1 +1,0 @@
-PRAX=ejpfkiblcablembkdhcofhokccbbppnc

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -6,10 +6,11 @@
   "description": "chrome-extension",
   "type": "module",
   "scripts": {
-    "build": "pnpm bundle",
-    "bundle": "NODE_OPTIONS=\"--import=./src/utils/webpack-register.js\" webpack",
-    "clean": "rm -rfv dist bin",
-    "dev": "NODE_ENV=testnet pnpm bundle --watch --mode=development -d inline-source-map",
+    "build": "pnpm bundle:beta && pnpm bundle:prod",
+    "bundle:prod": "NODE_OPTIONS=\"--import=./src/utils/webpack-register.js\" webpack --config webpack.prod-config.ts",
+    "bundle:beta": "NODE_OPTIONS=\"--import=./src/utils/webpack-register.js\" webpack --config webpack.beta-config.ts",
+    "clean": "rm -rfv dist beta-dist bin",
+    "dev": "NODE_ENV=testnet pnpm bundle:prod --watch --mode=development -d inline-source-map",
     "lint": "eslint src",
     "test": "vitest run"
   },

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -7,8 +7,8 @@
   "type": "module",
   "scripts": {
     "build": "pnpm bundle:beta && pnpm bundle:prod",
-    "bundle:prod": "NODE_OPTIONS=\"--import=./src/utils/webpack-register.js\" webpack --config webpack.prod-config.ts",
     "bundle:beta": "NODE_OPTIONS=\"--import=./src/utils/webpack-register.js\" webpack --config webpack.beta-config.ts",
+    "bundle:prod": "NODE_OPTIONS=\"--import=./src/utils/webpack-register.js\" webpack --config webpack.prod-config.ts",
     "clean": "rm -rfv dist beta-dist bin",
     "dev": "NODE_ENV=testnet pnpm bundle:prod --watch --mode=development -d inline-source-map",
     "lint": "eslint src",

--- a/apps/extension/public/beta-manifest.json
+++ b/apps/extension/public/beta-manifest.json
@@ -1,0 +1,51 @@
+{
+  "manifest_version": 3,
+  "name": "Prax wallet BETA",
+  "version": "14.0.0",
+  "description": "THIS EXTENSION IS FOR BETA TESTING",
+  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAhxDXNrlRB72kw+MeeofiBvJuuSkcMI+ZshYS9jve+Zhm0YlYUF/3mriz1D7jdK/U11EjKYMYCTQQEDLmSdQ8Q52ur3ei4u4gjyEpl/+QnjciR7msoziKH48Bia1U+wd53eW3TWNP/vpSJiBsAfOisEPox6w4lC5a03aCXV3xtkzfW0rebZrOLf1xhZD8mc4N9LU289E3cYRlBmfI4qxkBM1r7t9N4KsXle3VWXSn18joKzgzAWK+VhZtZu3xrwMQGpUqn+KyYFvawSGmYdDsnT6y0KS96V3CPp6rQHNfjItB/F4d1JQv1tskc959jiK9CuGbU57D9JHJ+1C9aOb0BwIDAQAB",
+  "minimum_chrome_version": "119",
+  "action": {
+    "default_popup": "popup.html"
+  },
+  "icons": {
+    "16": "favicon/beta/icon16.png",
+    "32": "favicon/beta/icon32.png",
+    "48": "favicon/beta/icon48.png",
+    "128": "favicon/beta/icon128.png"
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://*/*", "http://localhost/*"],
+      "js": ["injected-connection-port.js", "injected-request-listener.js"],
+      "run_at": "document_start"
+    },
+    {
+      "matches": ["https://*/*", "http://localhost/*"],
+      "js": ["injected-penumbra-global.js"],
+      "run_at": "document_start",
+      "world": "MAIN"
+    }
+  ],
+  "options_ui": {
+    "page": "page.html",
+    "open_in_tab": true
+  },
+  "background": {
+    "service_worker": "service-worker.js"
+  },
+  "web_accessible_resources": [
+    {
+      "resources": ["manifest.json", "favicon/*"],
+      "matches": ["<all_urls>"]
+    }
+  ],
+  "permissions": ["storage", "unlimitedStorage", "offscreen"],
+  "host_permissions": ["<all_urls>"],
+  "externally_connectable": {
+    "matches": ["<all_urls>"]
+  },
+  "content_security_policy": {
+    "extension_pages": "object-src 'self'; script-src 'self' 'wasm-unsafe-eval'"
+  }
+}

--- a/apps/extension/src/utils/zip-extension.ts
+++ b/apps/extension/src/utils/zip-extension.ts
@@ -1,38 +1,19 @@
-import * as fs from 'fs';
 import * as path from 'path';
 import child_process from 'child_process';
-import type Manifest from '../../public/manifest.json';
 
 const WORKING_DIR = process.cwd(); // Should be run at root dir of repo
-const MANIFEST_PATH = path.join(WORKING_DIR, 'apps/extension/dist/manifest.json');
-const DIST_PATH = path.join(WORKING_DIR, 'apps/extension/dist');
+const DIST_PROD_PATH = path.join(WORKING_DIR, 'apps/extension/dist');
+const DIST_BETA_PATH = path.join(WORKING_DIR, 'apps/extension/beta-dist');
 const PROD_ZIP_PATH = path.join(WORKING_DIR, 'prod.zip');
 const BETA_ZIP_PATH = path.join(WORKING_DIR, 'beta.zip');
 
-const updateManifestToBeta = (): void => {
-  const manifestData = fs.readFileSync(MANIFEST_PATH, 'utf-8');
-  const manifest = JSON.parse(manifestData) as typeof Manifest;
-
-  manifest.name = 'Prax wallet BETA';
-  manifest.description = 'THIS EXTENSION IS FOR BETA TESTING';
-  manifest.key =
-    'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAhxDXNrlRB72kw+MeeofiBvJuuSkcMI+ZshYS9jve+Zhm0YlYUF/3mriz1D7jdK/U11EjKYMYCTQQEDLmSdQ8Q52ur3ei4u4gjyEpl/+QnjciR7msoziKH48Bia1U+wd53eW3TWNP/vpSJiBsAfOisEPox6w4lC5a03aCXV3xtkzfW0rebZrOLf1xhZD8mc4N9LU289E3cYRlBmfI4qxkBM1r7t9N4KsXle3VWXSn18joKzgzAWK+VhZtZu3xrwMQGpUqn+KyYFvawSGmYdDsnT6y0KS96V3CPp6rQHNfjItB/F4d1JQv1tskc959jiK9CuGbU57D9JHJ+1C9aOb0BwIDAQAB';
-  manifest.icons['16'] = 'favicon/beta/icon16.png';
-  manifest.icons['32'] = 'favicon/beta/icon32.png';
-  manifest.icons['48'] = 'favicon/beta/icon48.png';
-  manifest.icons['128'] = 'favicon/beta/icon128.png';
-
-  fs.writeFileSync(MANIFEST_PATH, JSON.stringify(manifest, null, 2));
-};
-
-const zipDirectory = (path: string) => {
-  child_process.execSync(`zip -r ${path} .`, { cwd: DIST_PATH, stdio: 'inherit' });
+const zipDirectory = (path: string, dist: string) => {
+  child_process.execSync(`zip -r ${path} .`, { cwd: dist, stdio: 'inherit' });
 };
 
 const main = () => {
-  zipDirectory(PROD_ZIP_PATH);
-  updateManifestToBeta();
-  zipDirectory(BETA_ZIP_PATH);
+  zipDirectory(PROD_ZIP_PATH, DIST_PROD_PATH);
+  zipDirectory(BETA_ZIP_PATH, DIST_BETA_PATH);
 };
 
 main();

--- a/apps/extension/webpack.beta-config.ts
+++ b/apps/extension/webpack.beta-config.ts
@@ -1,0 +1,33 @@
+import dotenv from 'dotenv';
+import path from 'node:path';
+import CopyPlugin from 'copy-webpack-plugin';
+
+import config from './webpack.config.js';
+
+dotenv.config({ path: '.env.beta', override: true });
+
+const __dirname = new URL('.', import.meta.url).pathname;
+
+// Copies the beta manifest file after the build to replace the default manifest
+const BetaManifestReplacerPlugin = new CopyPlugin({
+  patterns: [
+    {
+      from: path.resolve(__dirname, 'public/beta-manifest.json'),
+      to: path.resolve(__dirname, 'beta-dist/manifest.json'),
+      force: true,
+    },
+  ],
+});
+
+/**
+ * This config overrides the env file for the extension, changes the output directory,
+ * and modifies the `manifest.json` file to use the beta extension ID
+ */
+export default ({ WEBPACK_WATCH = false }: { ['WEBPACK_WATCH']?: boolean }) => {
+  const appliedConfig = config({ WEBPACK_WATCH });
+
+  appliedConfig.output!.path = path.join(__dirname, 'beta-dist');
+  appliedConfig.plugins!.push(BetaManifestReplacerPlugin);
+
+  return appliedConfig;
+};

--- a/apps/extension/webpack.beta-config.ts
+++ b/apps/extension/webpack.beta-config.ts
@@ -1,10 +1,7 @@
-import dotenv from 'dotenv';
 import path from 'node:path';
 import CopyPlugin from 'copy-webpack-plugin';
 
 import config from './webpack.config.js';
-
-dotenv.config({ path: '.env.beta', override: true });
 
 const __dirname = new URL('.', import.meta.url).pathname;
 
@@ -19,12 +16,14 @@ const BetaManifestReplacerPlugin = new CopyPlugin({
   ],
 });
 
+const PRAX_ID = 'ejpfkiblcablembkdhcofhokccbbppnc';
+
 /**
- * This config overrides the env file for the extension, changes the output directory,
- * and modifies the `manifest.json` file to use the beta extension ID
+ * This config defines the Prax Chrome ID, changes the output directory,
+ * and modifies the `manifest.json` file to use the correct extension information
  */
 export default ({ WEBPACK_WATCH = false }: { ['WEBPACK_WATCH']?: boolean }) => {
-  const appliedConfig = config({ WEBPACK_WATCH });
+  const appliedConfig = config({ PRAX_ID, WEBPACK_WATCH });
 
   appliedConfig.output!.path = path.join(__dirname, 'beta-dist');
   appliedConfig.plugins!.push(BetaManifestReplacerPlugin);

--- a/apps/extension/webpack.config.ts
+++ b/apps/extension/webpack.config.ts
@@ -5,7 +5,6 @@
 import rootPackageJson from '../../package.json' with { type: 'json' };
 
 import CopyPlugin from 'copy-webpack-plugin';
-import dotenv from 'dotenv';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import { spawn } from 'node:child_process';
 import path from 'node:path';
@@ -14,224 +13,223 @@ import { type WebExtRunner, cmd as WebExtCmd } from 'web-ext';
 import webpack from 'webpack';
 import WatchExternalFilesPlugin from 'webpack-watch-external-files-plugin';
 
-// Loads default vars from `.env` file in this directory.
-dotenv.config({ path: '.env' });
-
-const keysPackage = path.dirname(url.fileURLToPath(import.meta.resolve('@penumbra-zone/keys')));
-
-const localPackages = [
-  ...Object.values(rootPackageJson.dependencies),
-  ...Object.values(rootPackageJson.devDependencies),
-
-  /* eslint-disable */
-  // typescript and eslint will recognize the literal type of local json.
-  // this is the simplest way to shut them both up.
-  ...Object.values(((rootPackageJson as any).pnpm?.overrides ?? {}) as Record<string, string>),
-  /* eslint-enable */
-]
-  .filter(specifier => specifier.endsWith('.tgz'))
-  .map(tgzSpecifier =>
-    tgzSpecifier.startsWith('file:') ? url.fileURLToPath(tgzSpecifier) : tgzSpecifier,
-  );
-
-const __dirname = new URL('.', import.meta.url).pathname;
-const srcDir = path.join(__dirname, 'src');
-const entryDir = path.join(srcDir, 'entry');
-const injectDir = path.join(srcDir, 'content-scripts');
-
-const CHROMIUM_PROFILE = process.env['CHROMIUM_PROFILE'];
-
-/*
- * The DefinePlugin replaces specified tokens with specified values.
- * - These should be declared in `prax.d.ts` for TypeScript awareness.
- * - `process.env.NODE_ENV` and other env vars are implicitly defined.
- * - Replacement is literal, so the values must be stringified.
- */
-const DefinePlugin = new webpack.DefinePlugin({
-  PRAX: JSON.stringify(process.env['PRAX']),
-  PRAX_ORIGIN: JSON.stringify(`chrome-extension://${process.env['PRAX']}`),
-  'globalThis.__DEV__': JSON.stringify(process.env['NODE_ENV'] !== 'production'),
-  'globalThis.__ASSERT_ROOT__': JSON.stringify(false),
-});
-
-const WebExtReloadPlugin = {
-  webExtRun: undefined as WebExtRunner | undefined,
-  apply({ hooks }: webpack.Compiler) {
-    hooks.afterEmit.tapPromise(
-      { name: 'WebExt Reloader' },
-      async ({ options }: webpack.Compilation) => {
-        await this.webExtRun?.reloadAllExtensions();
-        this.webExtRun ??= await WebExtCmd.run({
-          target: 'chromium',
-          chromiumProfile: CHROMIUM_PROFILE,
-          keepProfileChanges: Boolean(CHROMIUM_PROFILE),
-          profileCreateIfMissing: Boolean(CHROMIUM_PROFILE),
-          sourceDir: options.output.path,
-          startUrl: 'https://localhost:5173/',
-        });
-        this.webExtRun.registerCleanup(() => (this.webExtRun = undefined));
-      },
-    );
-  },
-};
-
-/**
- * This custom plugin will run `pnpm install` before each watch-mode build. This
- * combined with WatchExternalFilesPlugin will ensure that tarball dependencies
- * are updated when they change.
- */
-const PnpmInstallPlugin = {
-  apply: ({ hooks }: webpack.Compiler) =>
-    hooks.watchRun.tapPromise(
-      { name: 'CustomPnpmInstallPlugin' },
-      compiler =>
-        new Promise<void>((resolve, reject) => {
-          const pnpmInstall = spawn(
-            'pnpm',
-            // --ignore-scripts because syncpack doesn't like to run under
-            // webpack for some reason. watch out for post-install scripts that
-            // dependencies might need.
-            ['-w', 'install', '--ignore-scripts'],
-            { stdio: 'inherit' },
-          );
-          pnpmInstall.on('exit', code => {
-            if (code) {
-              reject(new Error(`pnpm install failed ${code}`));
-            } else {
-              // clear webpack's cache to ensure new deps are used
-              compiler.purgeInputFileSystem();
-              resolve();
-            }
-          });
-        }),
-    ),
-};
-
 export default ({
   WEBPACK_WATCH = false,
 }: {
   ['WEBPACK_WATCH']?: boolean;
-}): webpack.Configuration => ({
-  entry: {
-    'injected-connection-port': path.join(injectDir, 'injected-connection-port.ts'),
-    'injected-penumbra-global': path.join(injectDir, 'injected-penumbra-global.ts'),
-    'injected-request-listener': path.join(injectDir, 'injected-request-listener.ts'),
-    'offscreen-handler': path.join(entryDir, 'offscreen-handler.ts'),
-    'page-root': path.join(entryDir, 'page-root.tsx'),
-    'popup-root': path.join(entryDir, 'popup-root.tsx'),
-    'service-worker': path.join(srcDir, 'service-worker.ts'),
-    'wasm-build-action': path.join(srcDir, 'wasm-build-action.ts'),
-  },
-  output: {
-    path: path.join(__dirname, 'dist'),
-    filename: '[name].js',
-  },
-  optimization: {
-    splitChunks: {
-      chunks: chunk => {
-        const filesNotToChunk = [
-          'injected-connection-port',
-          'injected-penumbra-global',
-          'injected-request-listner',
-          'service-worker',
-          'wasm-build-action',
-        ];
-        return chunk.name ? !filesNotToChunk.includes(chunk.name) : false;
-      },
+}): webpack.Configuration => {
+  const keysPackage = path.dirname(url.fileURLToPath(import.meta.resolve('@penumbra-zone/keys')));
+
+  const localPackages = [
+    ...Object.values(rootPackageJson.dependencies),
+    ...Object.values(rootPackageJson.devDependencies),
+
+    /* eslint-disable */
+    // typescript and eslint will recognize the literal type of local json.
+    // this is the simplest way to shut them both up.
+    ...Object.values(((rootPackageJson as any).pnpm?.overrides ?? {}) as Record<string, string>),
+    /* eslint-enable */
+  ]
+    .filter(specifier => specifier.endsWith('.tgz'))
+    .map(tgzSpecifier =>
+      tgzSpecifier.startsWith('file:') ? url.fileURLToPath(tgzSpecifier) : tgzSpecifier,
+    );
+
+  const __dirname = new URL('.', import.meta.url).pathname;
+  const srcDir = path.join(__dirname, 'src');
+  const entryDir = path.join(srcDir, 'entry');
+  const injectDir = path.join(srcDir, 'content-scripts');
+
+  const CHROMIUM_PROFILE = process.env['CHROMIUM_PROFILE'];
+
+  /*
+   * The DefinePlugin replaces specified tokens with specified values.
+   * - These should be declared in `prax.d.ts` for TypeScript awareness.
+   * - `process.env.NODE_ENV` and other env vars are implicitly defined.
+   * - Replacement is literal, so the values must be stringified.
+   */
+  const DefinePlugin = new webpack.DefinePlugin({
+    PRAX: JSON.stringify(process.env['PRAX']),
+    PRAX_ORIGIN: JSON.stringify(`chrome-extension://${process.env['PRAX']}`),
+    'globalThis.__DEV__': JSON.stringify(process.env['NODE_ENV'] !== 'production'),
+    'globalThis.__ASSERT_ROOT__': JSON.stringify(false),
+  });
+
+  const WebExtReloadPlugin = {
+    webExtRun: undefined as WebExtRunner | undefined,
+    apply({ hooks }: webpack.Compiler) {
+      hooks.afterEmit.tapPromise(
+        { name: 'WebExt Reloader' },
+        async ({ options }: webpack.Compilation) => {
+          await this.webExtRun?.reloadAllExtensions();
+          this.webExtRun ??= await WebExtCmd.run({
+            target: 'chromium',
+            chromiumProfile: CHROMIUM_PROFILE,
+            keepProfileChanges: Boolean(CHROMIUM_PROFILE),
+            profileCreateIfMissing: Boolean(CHROMIUM_PROFILE),
+            sourceDir: options.output.path,
+            startUrl: 'https://localhost:5173/',
+          });
+          this.webExtRun.registerCleanup(() => (this.webExtRun = undefined));
+        },
+      );
     },
-  },
-  module: {
-    rules: [
-      {
-        test: /\.tsx?$/,
-        use: 'ts-loader',
-        exclude: /node_modules/,
-      },
-      {
-        test: /\.m?js/,
-        resolve: {
-          fullySpecified: false,
+  };
+
+  /**
+   * This custom plugin will run `pnpm install` before each watch-mode build. This
+   * combined with WatchExternalFilesPlugin will ensure that tarball dependencies
+   * are updated when they change.
+   */
+  const PnpmInstallPlugin = {
+    apply: ({ hooks }: webpack.Compiler) =>
+      hooks.watchRun.tapPromise(
+        { name: 'CustomPnpmInstallPlugin' },
+        compiler =>
+          new Promise<void>((resolve, reject) => {
+            const pnpmInstall = spawn(
+              'pnpm',
+              // --ignore-scripts because syncpack doesn't like to run under
+              // webpack for some reason. watch out for post-install scripts that
+              // dependencies might need.
+              ['-w', 'install', '--ignore-scripts'],
+              { stdio: 'inherit' },
+            );
+            pnpmInstall.on('exit', code => {
+              if (code) {
+                reject(new Error(`pnpm install failed ${code}`));
+              } else {
+                // clear webpack's cache to ensure new deps are used
+                compiler.purgeInputFileSystem();
+                resolve();
+              }
+            });
+          }),
+      ),
+  };
+
+  return {
+    entry: {
+      'injected-connection-port': path.join(injectDir, 'injected-connection-port.ts'),
+      'injected-penumbra-global': path.join(injectDir, 'injected-penumbra-global.ts'),
+      'injected-request-listener': path.join(injectDir, 'injected-request-listener.ts'),
+      'offscreen-handler': path.join(entryDir, 'offscreen-handler.ts'),
+      'page-root': path.join(entryDir, 'page-root.tsx'),
+      'popup-root': path.join(entryDir, 'popup-root.tsx'),
+      'service-worker': path.join(srcDir, 'service-worker.ts'),
+      'wasm-build-action': path.join(srcDir, 'wasm-build-action.ts'),
+    },
+    output: {
+      path: path.join(__dirname, 'dist'),
+      filename: '[name].js',
+    },
+    optimization: {
+      splitChunks: {
+        chunks: chunk => {
+          const filesNotToChunk = [
+            'injected-connection-port',
+            'injected-penumbra-global',
+            'injected-request-listner',
+            'service-worker',
+            'wasm-build-action',
+          ];
+          return chunk.name ? !filesNotToChunk.includes(chunk.name) : false;
         },
       },
-      {
-        test: /\.css$/i,
-        use: [
-          'style-loader',
-          'css-loader',
-          {
-            loader: 'postcss-loader',
-            options: {
-              postcssOptions: {
-                ident: 'postcss',
-                plugins: ['tailwindcss', 'autoprefixer'],
+    },
+    module: {
+      rules: [
+        {
+          test: /\.tsx?$/,
+          use: 'ts-loader',
+          exclude: /node_modules/,
+        },
+        {
+          test: /\.m?js/,
+          resolve: {
+            fullySpecified: false,
+          },
+        },
+        {
+          test: /\.css$/i,
+          use: [
+            'style-loader',
+            'css-loader',
+            {
+              loader: 'postcss-loader',
+              options: {
+                postcssOptions: {
+                  ident: 'postcss',
+                  plugins: ['tailwindcss', 'autoprefixer'],
+                },
               },
             },
-          },
-        ],
-      },
-      {
-        test: /\.mp4$/,
-        type: 'asset/resource',
-        generator: {
-          filename: 'videos/[hash][ext][query]',
+          ],
         },
-      },
-    ],
-  },
-  resolve: {
-    extensions: ['.ts', '.tsx', '.js'],
-    alias: {
-      '@ui': path.resolve(__dirname, '../../packages/ui'),
-    },
-  },
-  plugins: [
-    new webpack.CleanPlugin(),
-    new webpack.ProvidePlugin({
-      // Required by the `bip39` library
-      Buffer: ['buffer', 'Buffer'],
-    }),
-    new webpack.IgnorePlugin({
-      // Not required by the `bip39` library, but very nice
-      checkResource(resource) {
-        return /.*\/wordlists\/(?!english).*\.json/.test(resource);
-      },
-    }),
-    DefinePlugin,
-    new CopyPlugin({
-      patterns: [
-        'public',
         {
-          from: path.join(keysPackage, 'keys', '*_pk.bin'),
-          to: 'keys/[name][ext]',
+          test: /\.mp4$/,
+          type: 'asset/resource',
+          generator: {
+            filename: 'videos/[hash][ext][query]',
+          },
         },
       ],
-    }),
-    // html entry points
-    new HtmlWebpackPlugin({
-      favicon: 'public/favicon/icon128.png',
-      title: 'Prax Wallet',
-      template: 'react-root.html',
-      filename: 'page.html',
-      chunks: ['page-root'],
-    }),
-    new HtmlWebpackPlugin({
-      title: 'Prax Wallet',
-      template: 'react-root.html',
-      rootId: 'popup-root',
-      filename: 'popup.html',
-      chunks: ['popup-root'],
-    }),
-    new HtmlWebpackPlugin({
-      title: 'Penumbra Offscreen',
-      filename: 'offscreen.html',
-      chunks: ['offscreen-handler'],
-    }),
-    // watch tarballs for changes
-    WEBPACK_WATCH && new WatchExternalFilesPlugin({ files: localPackages }),
-    WEBPACK_WATCH && PnpmInstallPlugin,
-    CHROMIUM_PROFILE && WebExtReloadPlugin,
-  ],
-  experiments: {
-    asyncWebAssembly: true,
-  },
-});
+    },
+    resolve: {
+      extensions: ['.ts', '.tsx', '.js'],
+      alias: {
+        '@ui': path.resolve(__dirname, '../../packages/ui'),
+      },
+    },
+    plugins: [
+      new webpack.CleanPlugin(),
+      new webpack.ProvidePlugin({
+        // Required by the `bip39` library
+        Buffer: ['buffer', 'Buffer'],
+      }),
+      new webpack.IgnorePlugin({
+        // Not required by the `bip39` library, but very nice
+        checkResource(resource) {
+          return /.*\/wordlists\/(?!english).*\.json/.test(resource);
+        },
+      }),
+      DefinePlugin,
+      new CopyPlugin({
+        patterns: [
+          'public',
+          {
+            from: path.join(keysPackage, 'keys', '*_pk.bin'),
+            to: 'keys/[name][ext]',
+          },
+        ],
+      }),
+      // html entry points
+      new HtmlWebpackPlugin({
+        favicon: 'public/favicon/icon128.png',
+        title: 'Prax Wallet',
+        template: 'react-root.html',
+        filename: 'page.html',
+        chunks: ['page-root'],
+      }),
+      new HtmlWebpackPlugin({
+        title: 'Prax Wallet',
+        template: 'react-root.html',
+        rootId: 'popup-root',
+        filename: 'popup.html',
+        chunks: ['popup-root'],
+      }),
+      new HtmlWebpackPlugin({
+        title: 'Penumbra Offscreen',
+        filename: 'offscreen.html',
+        chunks: ['offscreen-handler'],
+      }),
+      // watch tarballs for changes
+      WEBPACK_WATCH && new WatchExternalFilesPlugin({ files: localPackages }),
+      WEBPACK_WATCH && PnpmInstallPlugin,
+      CHROMIUM_PROFILE && WebExtReloadPlugin,
+    ],
+    experiments: {
+      asyncWebAssembly: true,
+    },
+  };
+};

--- a/apps/extension/webpack.config.ts
+++ b/apps/extension/webpack.config.ts
@@ -15,8 +15,10 @@ import WatchExternalFilesPlugin from 'webpack-watch-external-files-plugin';
 
 export default ({
   WEBPACK_WATCH = false,
+  PRAX_ID,
 }: {
   ['WEBPACK_WATCH']?: boolean;
+  PRAX_ID: string;
 }): webpack.Configuration => {
   const keysPackage = path.dirname(url.fileURLToPath(import.meta.resolve('@penumbra-zone/keys')));
 
@@ -49,8 +51,8 @@ export default ({
    * - Replacement is literal, so the values must be stringified.
    */
   const DefinePlugin = new webpack.DefinePlugin({
-    PRAX: JSON.stringify(process.env['PRAX']),
-    PRAX_ORIGIN: JSON.stringify(`chrome-extension://${process.env['PRAX']}`),
+    PRAX: PRAX_ID,
+    PRAX_ORIGIN: JSON.stringify(`chrome-extension://${PRAX_ID}`),
     'globalThis.__DEV__': JSON.stringify(process.env['NODE_ENV'] !== 'production'),
     'globalThis.__ASSERT_ROOT__': JSON.stringify(false),
   });

--- a/apps/extension/webpack.prod-config.ts
+++ b/apps/extension/webpack.prod-config.ts
@@ -1,0 +1,17 @@
+/**
+ * This config overrides the env file for the extension and changes the output directory
+ */
+
+import dotenv from 'dotenv';
+import path from 'node:path';
+import config from './webpack.config.js';
+
+dotenv.config({ path: '.env', override: true });
+
+const __dirname = new URL('.', import.meta.url).pathname;
+
+export default ({ WEBPACK_WATCH = false }: { ['WEBPACK_WATCH']?: boolean }) => {
+  const appliedConfig = config({ WEBPACK_WATCH });
+  appliedConfig.output!.path = path.join(__dirname, 'dist');
+  return appliedConfig;
+};

--- a/apps/extension/webpack.prod-config.ts
+++ b/apps/extension/webpack.prod-config.ts
@@ -1,17 +1,15 @@
-/**
- * This config overrides the env file for the extension and changes the output directory
- */
-
-import dotenv from 'dotenv';
 import path from 'node:path';
 import config from './webpack.config.js';
 
-dotenv.config({ path: '.env', override: true });
-
 const __dirname = new URL('.', import.meta.url).pathname;
 
+const PRAX_ID = 'lkpmkhpnhknhmibgnmmhdhgdilepfghe';
+
+/**
+ * This config defines the Prax Chrome ID and the output directory
+ */
 export default ({ WEBPACK_WATCH = false }: { ['WEBPACK_WATCH']?: boolean }) => {
-  const appliedConfig = config({ WEBPACK_WATCH });
+  const appliedConfig = config({ PRAX_ID, WEBPACK_WATCH });
   appliedConfig.output!.path = path.join(__dirname, 'dist');
   return appliedConfig;
 };

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "clean": "turbo clean",
     "clean:modules": "rm -rf node_modules apps/*/node_modules packages/*/node_modules pnpm-lock.yaml",
     "clean:vitest-mjs": "find . -type f -name 'vite*.config.ts.timestamp-*-*.mjs' -ls -delete",
-    "zip": "pnpm tsx apps/extension/src/utils/zip-extension.ts",
     "compile": "turbo compile",
     "dev": "turbo dev",
     "format": "turbo format",
@@ -26,7 +25,8 @@
     "pretest": "playwright install",
     "test": "turbo test",
     "test:rust": "turbo test:rust",
-    "watch-and-repack": "./scripts/watch-and-repack.sh"
+    "watch-and-repack": "./scripts/watch-and-repack.sh",
+    "zip": "pnpm tsx apps/extension/src/utils/zip-extension.ts"
   },
   "dependencies": {
     "@bufbuild/protobuf": "^1.x",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "clean": "turbo clean",
     "clean:modules": "rm -rf node_modules apps/*/node_modules packages/*/node_modules pnpm-lock.yaml",
     "clean:vitest-mjs": "find . -type f -name 'vite*.config.ts.timestamp-*-*.mjs' -ls -delete",
+    "zip": "pnpm tsx apps/extension/src/utils/zip-extension.ts",
     "compile": "turbo compile",
     "dev": "turbo dev",
     "format": "turbo format",


### PR DESCRIPTION
Relates to https://github.com/penumbra-zone/web/issues/1811

The extension relies on the `.env` file that sets the `PRAX` variable with the chrome extension ID. This ID is then used to correctly inject the provider to web pages. The build process didn't consider it, and the BETA extension injected the prod ID. The `client` package, in its turn, always checks the injected id matches chrome manifest to avoid security breaches, – it all means the BETA package didn't work completely.

This PR fixes the issue with BETA extension not being built correctly:
- Separates webpack bundles into the `prod` and `beta` versions
- Removes the `.env` files in favor of string replacements
- Beta bundle produces the `beta-dist` directory
- Beta bundle also modifies the `manifest.json` file to update favicons and info about the extension