### PR TITLE
fix(ui): #225: change 'account' to 'sub-account'

### DIFF
--- a/packages/ui/components/ui/account-switcher/account-switcher.test.tsx
+++ b/packages/ui/components/ui/account-switcher/account-switcher.test.tsx
@@ -6,7 +6,7 @@ describe('<AccountSwitcher />', () => {
   it('renders the current account', () => {
     const { getByLabelText } = render(<AccountSwitcher account={123} onChange={vi.fn()} />);
 
-    expect(getByLabelText('Account #123')).toHaveValue(123);
+    expect(getByLabelText('Sub-Account #123')).toHaveValue(123);
   });
 
   describe('changing the account via the input field', () => {
@@ -15,14 +15,14 @@ describe('<AccountSwitcher />', () => {
       const { getByLabelText } = render(<AccountSwitcher account={123} onChange={onChange} />);
 
       expect(onChange).not.toHaveBeenCalled();
-      fireEvent.change(getByLabelText('Account #123'), { target: { value: 456 } });
+      fireEvent.change(getByLabelText('Sub-Account #123'), { target: { value: 456 } });
       expect(onChange).toHaveBeenCalledWith(456);
     });
 
     it('has aria-disabled=false', () => {
       const { getByLabelText } = render(<AccountSwitcher account={123} onChange={vi.fn()} />);
 
-      expect(getByLabelText('Account #123')).toHaveAttribute('aria-disabled', 'false');
+      expect(getByLabelText('Sub-Account #123')).toHaveAttribute('aria-disabled', 'false');
     });
 
     describe('when a filter has been passed', () => {
@@ -32,7 +32,7 @@ describe('<AccountSwitcher />', () => {
           <AccountSwitcher account={123} onChange={onChange} filter={[1, 2, 3]} />,
         );
 
-        fireEvent.change(getByLabelText('Account #123'), { target: { value: 456 } });
+        fireEvent.change(getByLabelText('Sub-Account #123'), { target: { value: 456 } });
         expect(onChange).not.toHaveBeenCalled();
       });
 
@@ -41,7 +41,7 @@ describe('<AccountSwitcher />', () => {
           <AccountSwitcher account={123} onChange={vi.fn()} filter={[1, 2, 3]} />,
         );
 
-        expect(getByLabelText('Account #123')).toHaveAttribute('aria-disabled', 'true');
+        expect(getByLabelText('Sub-Account #123')).toHaveAttribute('aria-disabled', 'true');
       });
     });
   });
@@ -52,14 +52,14 @@ describe('<AccountSwitcher />', () => {
       const { getByLabelText } = render(<AccountSwitcher account={123} onChange={onChange} />);
 
       expect(onChange).not.toHaveBeenCalled();
-      fireEvent.click(getByLabelText('Previous account'));
+      fireEvent.click(getByLabelText('Previous sub-account'));
       expect(onChange).toHaveBeenCalledWith(122);
     });
 
     it("is disabled when we're at account 0", () => {
       const { queryByLabelText } = render(<AccountSwitcher account={0} onChange={vi.fn()} />);
 
-      expect(queryByLabelText('Previous account')?.parentElement).toBeDisabled();
+      expect(queryByLabelText('Previous sub-account')?.parentElement).toBeDisabled();
     });
 
     describe('when a filter has been passed', () => {
@@ -70,7 +70,7 @@ describe('<AccountSwitcher />', () => {
         );
 
         expect(onChange).not.toHaveBeenCalled();
-        fireEvent.click(getByLabelText('Previous account'));
+        fireEvent.click(getByLabelText('Previous sub-account'));
         expect(onChange).toHaveBeenCalledWith(100);
       });
 
@@ -79,7 +79,7 @@ describe('<AccountSwitcher />', () => {
           <AccountSwitcher account={100} onChange={vi.fn()} filter={[123, 100]} />,
         );
 
-        expect(queryByLabelText('Previous account')?.parentElement).toBeDisabled();
+        expect(queryByLabelText('Previous sub-account')?.parentElement).toBeDisabled();
       });
     });
   });
@@ -90,14 +90,14 @@ describe('<AccountSwitcher />', () => {
       const { getByLabelText } = render(<AccountSwitcher account={123} onChange={onChange} />);
 
       expect(onChange).not.toHaveBeenCalled();
-      fireEvent.click(getByLabelText('Next account'));
+      fireEvent.click(getByLabelText('Next sub-account'));
       expect(onChange).toHaveBeenCalledWith(124);
     });
 
     it("is disabled when we're at the maximum account index", () => {
       const { queryByLabelText } = render(<AccountSwitcher account={2 ** 32} onChange={vi.fn()} />);
 
-      expect(queryByLabelText('Next account')?.parentElement).toBeDisabled();
+      expect(queryByLabelText('Next sub-account')?.parentElement).toBeDisabled();
     });
 
     describe('when a filter has been passed', () => {
@@ -108,7 +108,7 @@ describe('<AccountSwitcher />', () => {
         );
 
         expect(onChange).not.toHaveBeenCalled();
-        fireEvent.click(getByLabelText('Next account'));
+        fireEvent.click(getByLabelText('Next sub-account'));
         expect(onChange).toHaveBeenCalledWith(123);
       });
 
@@ -117,7 +117,7 @@ describe('<AccountSwitcher />', () => {
           <AccountSwitcher account={123} onChange={vi.fn()} filter={[123, 100]} />,
         );
 
-        expect(queryByLabelText('Next account')?.parentElement).toBeDisabled();
+        expect(queryByLabelText('Next sub-account')?.parentElement).toBeDisabled();
       });
     });
   });

--- a/packages/ui/components/ui/account-switcher/index.tsx
+++ b/packages/ui/components/ui/account-switcher/index.tsx
@@ -68,7 +68,7 @@ export const AccountSwitcher = ({
         disabled={!previousButtonEnabled}
       >
         <ArrowLeftIcon
-          aria-label='Previous account'
+          aria-label='Previous sub-account'
           role='button'
           onClick={handleClickPrevious}
           className='size-6 hover:cursor-pointer'
@@ -76,42 +76,49 @@ export const AccountSwitcher = ({
       </Button>
       <div className='select-none text-center font-headline text-xl font-semibold leading-[30px]'>
         <div className='flex flex-row flex-wrap items-end gap-[6px]'>
-          <span>Account</span>
-          <div className='flex items-end gap-0'>
-            <p>#</p>
-            <div className='relative w-min min-w-[24px]'>
-              <Input
-                aria-label={`Account #${account}`}
-                aria-disabled={!!filter}
-                variant='transparent'
-                type='number'
-                className='mb-[3px] h-6 py-[2px] font-headline text-xl font-semibold leading-[30px]'
-                onChange={e => {
-                  /**
-                   * Don't allow manual account number entry when there's a
-                   * filter.
-                   *
-                   * @todo: Change this to only call `handleChange()` when the
-                   * user presses Enter? Then it could validate that the entered
-                   * account index is in the filter.
-                   */
-                  if (filter) {
-                    return;
-                  }
+          {account === 0 ? (
+            <span>Main Account</span>
+          ) : (
+            <>
+              <span>Sub-Account</span>
 
-                  const value = Number(e.target.value);
-                  const valueLength = e.target.value.replace(/^0+/, '').length;
+              <div className='flex items-end gap-0'>
+                <p>#</p>
+                <div className='relative w-min min-w-[24px]'>
+                  <Input
+                    aria-label={`Sub-Account #${account}`}
+                    aria-disabled={!!filter}
+                    variant='transparent'
+                    type='number'
+                    className='mb-[3px] h-6 py-[2px] font-headline text-xl font-semibold leading-[30px]'
+                    onChange={e => {
+                      /**
+                       * Don't allow manual account number entry when there's a
+                       * filter.
+                       *
+                       * @todo: Change this to only call `handleChange()` when the
+                       * user presses Enter? Then it could validate that the entered
+                       * account index is in the filter.
+                       */
+                      if (filter) {
+                        return;
+                      }
 
-                  if (value > MAX_INDEX || valueLength > MAX_INDEX.toString().length) {
-                    return;
-                  }
-                  handleChange(value);
-                }}
-                style={{ width: `${inputCharWidth}ch` }}
-                value={account ? account.toString().replace(/^0+/, '') : '0'} // Removes leading zeros (e.g. 00123 -> 123
-              />
-            </div>
-          </div>
+                      const value = Number(e.target.value);
+                      const valueLength = e.target.value.replace(/^0+/, '').length;
+
+                      if (value > MAX_INDEX || valueLength > MAX_INDEX.toString().length) {
+                        return;
+                      }
+                      handleChange(value);
+                    }}
+                    style={{ width: `${inputCharWidth}ch` }}
+                    value={account ? account.toString().replace(/^0+/, '') : '0'} // Removes leading zeros (e.g. 00123 -> 123
+                  />
+                </div>
+              </div>
+            </>
+          )}
         </div>
       </div>
       <Button
@@ -123,7 +130,7 @@ export const AccountSwitcher = ({
         disabled={!nextButtonEnabled}
       >
         <ArrowRightIcon
-          aria-label='Next account'
+          aria-label='Next sub-account'
           role='button'
           onClick={handleClickNext}
           className='size-6 hover:cursor-pointer'


### PR DESCRIPTION
Closes #225 

Changes the `AccountSwitcher` component to display `sub-account` and `main account` terms instead of `account`.

Main Account             |  Sub-Account #0
:-------------------------:|:-------------------------:
![](https://github.com/user-attachments/assets/25d66ddb-2ce2-45b3-95bc-859b09db7ded)  |  ![](https://github.com/user-attachments/assets/34fb9eab-8c9e-4c14-b3b1-562c34707427)

I also thought about the successful onboarding page but decided not to change:

<img width="645" alt="Screenshot 2024-11-11 at 10 46 17" src="https://github.com/user-attachments/assets/17e421e4-d8be-4e74-a841-7ef023605423">
