### PR TITLE
Correct import paths

### DIFF
--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -4,12 +4,7 @@
   "license": "(MIT OR Apache-2.0)",
   "type": "module",
   "scripts": {
-    "build": "tsc --build --verbose",
-    "clean": "rm -rfv dist *.tsbuildinfo package penumbra-zone-*.tgz",
-    "dev:pack": "tsc-watch --onSuccess \"$npm_execpath pack\"",
-    "lint": "eslint src",
-    "lint:fix": "eslint src --fix",
-    "lint:strict": "tsc --noEmit && eslint src --max-warnings 0",
+    "lint": "eslint \"**/*.ts*\"",
     "test": "vitest run"
   },
   "files": [

--- a/packages/query/src/block-processor.ts
+++ b/packages/query/src/block-processor.ts
@@ -26,11 +26,11 @@ import { ScanBlockResult } from '@penumbra-zone/types/state-commitment-tree';
 import { computePositionId, getLpNftMetadata } from '@penumbra-zone/wasm/dex';
 import { customizeSymbol } from '@penumbra-zone/wasm/metadata';
 import { backOff } from 'exponential-backoff';
-import { updatePricesFromSwaps } from './helpers/price-indexer.js';
-import { processActionDutchAuctionEnd } from './helpers/process-action-dutch-auction-end.js';
-import { processActionDutchAuctionSchedule } from './helpers/process-action-dutch-auction-schedule.js';
-import { processActionDutchAuctionWithdraw } from './helpers/process-action-dutch-auction-withdraw.js';
-import { RootQuerier } from './root-querier.js';
+import { updatePricesFromSwaps } from './helpers/price-indexer';
+import { processActionDutchAuctionEnd } from './helpers/process-action-dutch-auction-end';
+import { processActionDutchAuctionSchedule } from './helpers/process-action-dutch-auction-schedule';
+import { processActionDutchAuctionWithdraw } from './helpers/process-action-dutch-auction-withdraw';
+import { RootQuerier } from './root-querier';
 import { IdentityKey } from '@penumbra-zone/protobuf/penumbra/core/keys/v1/keys_pb';
 import { getDelegationTokenMetadata } from '@penumbra-zone/wasm/stake';
 import { toPlainMessage } from '@bufbuild/protobuf';
@@ -38,8 +38,8 @@ import { getAssetIdFromGasPrices } from '@penumbra-zone/getters/compact-block';
 import { getSpendableNoteRecordCommitment } from '@penumbra-zone/getters/spendable-note-record';
 import { getSwapRecordCommitment } from '@penumbra-zone/getters/swap-record';
 import { CompactBlock } from '@penumbra-zone/protobuf/penumbra/core/component/compact_block/v1/compact_block_pb';
-import { shouldSkipTrialDecrypt } from './helpers/skip-trial-decrypt.js';
-import { identifyTransactions, RelevantTx } from './helpers/identify-txs.js';
+import { shouldSkipTrialDecrypt } from './helpers/skip-trial-decrypt';
+import { identifyTransactions, RelevantTx } from './helpers/identify-txs';
 
 declare global {
   // eslint-disable-next-line no-var -- expected globals

--- a/packages/query/src/helpers/identify-txs.test.ts
+++ b/packages/query/src/helpers/identify-txs.test.ts
@@ -11,7 +11,7 @@ import {
   getCommitmentsFromActions,
   getNullifiersFromActions,
   identifyTransactions,
-} from './identify-txs.js';
+} from './identify-txs';
 import {
   Output,
   OutputBody,

--- a/packages/query/src/helpers/price-indexer.test.ts
+++ b/packages/query/src/helpers/price-indexer.test.ts
@@ -1,4 +1,4 @@
-import { deriveAndSavePriceFromBSOD } from './price-indexer.js';
+import { deriveAndSavePriceFromBSOD } from './price-indexer';
 import { BatchSwapOutputData } from '@penumbra-zone/protobuf/penumbra/core/component/dex/v1/dex_pb';
 import { beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 import { IndexedDbInterface } from '@penumbra-zone/types/indexed-db';

--- a/packages/query/src/helpers/process-action-dutch-auction-end.test.ts
+++ b/packages/query/src/helpers/process-action-dutch-auction-end.test.ts
@@ -1,5 +1,5 @@
 import { Mock, beforeEach, describe, expect, it, vi } from 'vitest';
-import { processActionDutchAuctionEnd } from './process-action-dutch-auction-end.js';
+import { processActionDutchAuctionEnd } from './process-action-dutch-auction-end';
 import { AssetId, Metadata, Value } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
 import {
   ActionDutchAuctionEnd,

--- a/packages/query/src/helpers/skip-trial-decrypt.test.ts
+++ b/packages/query/src/helpers/skip-trial-decrypt.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { shouldSkipTrialDecrypt } from './skip-trial-decrypt.js';
+import { shouldSkipTrialDecrypt } from './skip-trial-decrypt';
 
 describe('skipTrialDecrypt()', () => {
   it('should not skip trial decryption if walletCreationBlockHeight is undefined', () => {

--- a/packages/query/src/queriers/app.ts
+++ b/packages/query/src/queriers/app.ts
@@ -1,5 +1,5 @@
 import { PromiseClient } from '@connectrpc/connect';
-import { createClient } from './utils.js';
+import { createClient } from './utils';
 import { AppParameters } from '@penumbra-zone/protobuf/penumbra/core/app/v1/app_pb';
 import { Transaction } from '@penumbra-zone/protobuf/penumbra/core/transaction/v1/transaction_pb';
 import { AppService } from '@penumbra-zone/protobuf';

--- a/packages/query/src/queriers/auction.ts
+++ b/packages/query/src/queriers/auction.ts
@@ -1,7 +1,7 @@
 import { AuctionQuerierInterface } from '@penumbra-zone/types/querier';
 import { AuctionService } from '@penumbra-zone/protobuf';
 import { PromiseClient } from '@connectrpc/connect';
-import { createClient } from './utils.js';
+import { createClient } from './utils';
 import {
   AuctionId,
   DutchAuction,

--- a/packages/query/src/queriers/cnidarium.ts
+++ b/packages/query/src/queriers/cnidarium.ts
@@ -1,5 +1,5 @@
 import { PromiseClient } from '@connectrpc/connect';
-import { createClient } from './utils.js';
+import { createClient } from './utils';
 import { CnidariumService } from '@penumbra-zone/protobuf';
 import { KeyValueRequest } from '@penumbra-zone/protobuf/penumbra/cnidarium/v1/cnidarium_pb';
 import { CnidariumQuerierInterface } from '@penumbra-zone/types/querier';

--- a/packages/query/src/queriers/compact-block.ts
+++ b/packages/query/src/queriers/compact-block.ts
@@ -4,7 +4,7 @@ import {
   CompactBlockRangeRequest,
 } from '@penumbra-zone/protobuf/penumbra/core/component/compact_block/v1/compact_block_pb';
 import { CompactBlockService } from '@penumbra-zone/protobuf';
-import { createClient } from './utils.js';
+import { createClient } from './utils';
 import type {
   CompactBlockQuerierInterface,
   CompactBlockRangeParams,

--- a/packages/query/src/queriers/ibc-client.ts
+++ b/packages/query/src/queriers/ibc-client.ts
@@ -1,5 +1,5 @@
 import { PromiseClient } from '@connectrpc/connect';
-import { createClient } from './utils.js';
+import { createClient } from './utils';
 import { IbcClientService } from '@penumbra-zone/protobuf';
 import {
   QueryClientStatesRequest,

--- a/packages/query/src/queriers/sct.ts
+++ b/packages/query/src/queriers/sct.ts
@@ -1,5 +1,5 @@
 import { PromiseClient } from '@connectrpc/connect';
-import { createClient } from './utils.js';
+import { createClient } from './utils';
 import { SctService } from '@penumbra-zone/protobuf';
 import { SctQuerierInterface } from '@penumbra-zone/types/querier';
 import {

--- a/packages/query/src/queriers/shielded-pool.ts
+++ b/packages/query/src/queriers/shielded-pool.ts
@@ -1,5 +1,5 @@
 import { PromiseClient } from '@connectrpc/connect';
-import { createClient } from './utils.js';
+import { createClient } from './utils';
 import { ShieldedPoolService } from '@penumbra-zone/protobuf';
 import { AssetId, Metadata } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
 import type { ShieldedPoolQuerierInterface } from '@penumbra-zone/types/querier';

--- a/packages/query/src/queriers/staking.ts
+++ b/packages/query/src/queriers/staking.ts
@@ -1,5 +1,5 @@
 import { PromiseClient } from '@connectrpc/connect';
-import { createClient } from './utils.js';
+import { createClient } from './utils';
 import { StakeService } from '@penumbra-zone/protobuf';
 import {
   GetValidatorInfoRequest,

--- a/packages/query/src/queriers/tendermint.ts
+++ b/packages/query/src/queriers/tendermint.ts
@@ -1,5 +1,5 @@
 import { PromiseClient } from '@connectrpc/connect';
-import { createClient } from './utils.js';
+import { createClient } from './utils';
 import { TendermintProxyService } from '@penumbra-zone/protobuf';
 import { TransactionId } from '@penumbra-zone/protobuf/penumbra/core/txhash/v1/txhash_pb';
 import { Transaction } from '@penumbra-zone/protobuf/penumbra/core/transaction/v1/transaction_pb';

--- a/packages/query/src/root-querier.ts
+++ b/packages/query/src/root-querier.ts
@@ -1,13 +1,13 @@
-import { CompactBlockQuerier } from './queriers/compact-block.js';
-import { AppQuerier } from './queriers/app.js';
-import { TendermintQuerier } from './queriers/tendermint.js';
-import { ShieldedPoolQuerier } from './queriers/shielded-pool.js';
-import { IbcClientQuerier } from './queriers/ibc-client.js';
-import { CnidariumQuerier } from './queriers/cnidarium.js';
-import { StakeQuerier } from './queriers/staking.js';
+import { CompactBlockQuerier } from './queriers/compact-block';
+import { AppQuerier } from './queriers/app';
+import { TendermintQuerier } from './queriers/tendermint';
+import { ShieldedPoolQuerier } from './queriers/shielded-pool';
+import { IbcClientQuerier } from './queriers/ibc-client';
+import { CnidariumQuerier } from './queriers/cnidarium';
+import { StakeQuerier } from './queriers/staking';
 import type { RootQuerierInterface } from '@penumbra-zone/types/querier';
-import { AuctionQuerier } from './queriers/auction.js';
-import { SctQuerier } from './queriers/sct.js';
+import { AuctionQuerier } from './queriers/auction';
+import { SctQuerier } from './queriers/sct';
 
 // Given the amount of query services, this root querier aggregates them all
 // to make it easier for consumers


### PR DESCRIPTION
A follow up from https://github.com/prax-wallet/prax/pull/247

Legacy build methods causes the typescript compiler to create a bunch of compiled files locally. Also, fixes import paths that were throwing eslint errors after making the `lint` script the same as the other packages.