### PR TITLE
feat: idle syncing

### DIFF
--- a/apps/extension/public/manifest.json
+++ b/apps/extension/public/manifest.json
@@ -40,7 +40,7 @@
       "matches": ["<all_urls>"]
     }
   ],
-  "permissions": ["storage", "unlimitedStorage", "offscreen"],
+  "permissions": ["storage", "unlimitedStorage", "offscreen", "alarms"],
   "host_permissions": ["<all_urls>"],
   "externally_connectable": {
     "matches": ["<all_urls>"]

--- a/apps/extension/src/service-worker.ts
+++ b/apps/extension/src/service-worker.ts
@@ -96,3 +96,9 @@ const handler = await backOff(() => initHandler(), {
 });
 
 CRSessionManager.init(PRAX, handler);
+
+// https://developer.chrome.com/docs/extensions/reference/api/alarms
+chrome.alarms.create('blockSync', {
+  periodInMinutes: 30,
+  delayInMinutes: 0
+});

--- a/apps/extension/src/service-worker.ts
+++ b/apps/extension/src/service-worker.ts
@@ -102,3 +102,9 @@ void chrome.alarms.create('blockSync', {
   periodInMinutes: 30,
   delayInMinutes: 0,
 });
+
+chrome.alarms.onAlarm.addListener(alarm => {
+  if (alarm.name === 'blockSync') {
+    console.log('Block sync alarm fired, service worker restarting');
+  }
+});

--- a/apps/extension/src/service-worker.ts
+++ b/apps/extension/src/service-worker.ts
@@ -105,6 +105,8 @@ void chrome.alarms.create('blockSync', {
 
 chrome.alarms.onAlarm.addListener(alarm => {
   if (alarm.name === 'blockSync') {
-    console.log('Block sync alarm fired, service worker restarting');
+    if (globalThis.__DEV__) {
+      console.info('Background sync scheduled');
+    }
   }
 });

--- a/apps/extension/src/service-worker.ts
+++ b/apps/extension/src/service-worker.ts
@@ -98,7 +98,7 @@ const handler = await backOff(() => initHandler(), {
 CRSessionManager.init(PRAX, handler);
 
 // https://developer.chrome.com/docs/extensions/reference/api/alarms
-chrome.alarms.create('blockSync', {
+void chrome.alarms.create('blockSync', {
   periodInMinutes: 30,
-  delayInMinutes: 0
+  delayInMinutes: 0,
 });


### PR DESCRIPTION
uses [chrome.alarms](https://developer.chrome.com/docs/extensions/reference/api/alarms) API to restart the service worker after extended periods of inactivity and make sync progress over time without any frontend providers or the extension being opened. This ensures the chain is already synced when the user returns to penumbra after that extended period of not using it. We aptly name this '**idle syncing**'. 

- accompanying context doc: https://docs.google.com/document/d/18awgAeCIhwVLmfKj_R7pXoFTNtcOMtdtKhCWRs0iDgE/edit?tab=t.0
(this a long winded sanity check for sidestepping a major refactor to our connection lifecycle)

cc @hdevalence 

-------------------

when adding an event listener to log details as the alarm triggers (set `periodInMinutes` to 1 minute) and inspecting the service worker immediately after manually terminating it with `chrome.runtime.reload()`, it appears to working at first glance. However, we should contemplate potential pitfalls with this approach. 

<img width="1056" alt="Screenshot 2025-01-20 at 3 19 24 PM" src="https://github.com/user-attachments/assets/86e18442-df86-4ac5-b4d1-137baf0b7720" />

see https://github.com/prax-wallet/prax/pull/269#issuecomment-2608598293 for an example