### PR TITLE
prax: readable sync error message

### DIFF
--- a/packages/ui/components/ui/block-sync-status/index.tsx
+++ b/packages/ui/components/ui/block-sync-status/index.tsx
@@ -16,7 +16,7 @@ export const CondensedBlockSyncStatus = ({
   error?: unknown;
 }) => {
   if (error) {
-    return <BlockSyncErrorState error={error} />;
+    return <BlockSyncErrorState />;
   }
   if (!latestKnownBlockHeight || !fullSyncHeight) {
     return <AwaitingSyncState genesisSyncing={!fullSyncHeight} />;
@@ -41,7 +41,7 @@ export const CondensedBlockSyncStatus = ({
   );
 };
 
-const BlockSyncErrorState = ({ error }: { error: unknown }) => {
+const BlockSyncErrorState = () => {
   return (
     <motion.div
       className='flex w-full select-none flex-col'
@@ -51,7 +51,7 @@ const BlockSyncErrorState = ({ error }: { error: unknown }) => {
       <Progress status='error' value={100} shape='squared' />
       <div className='absolute flex w-full justify-between px-2'>
         <div className='mt-[-5.5px] font-mono text-[10px] text-red-300'>
-          Block sync error: {String(error)}
+          Block sync error. Ensure your internet connection is stable
         </div>
       </div>
     </motion.div>


### PR DESCRIPTION
replace illegible and unhelpful sync errors with a more human-readable error message.

pairs with https://github.com/penumbra-zone/web/pull/1997

---------

_before_

<img width="295" alt="Screenshot 2025-01-25 at 10 26 54 PM" src="https://github.com/user-attachments/assets/04291d23-3971-4fd1-8c1f-9e63b3084ea7" />

-----------

_after_

<img width="357" alt="Screenshot 2025-01-25 at 10 33 20 PM" src="https://github.com/user-attachments/assets/e592e42b-6253-416d-861f-6217cc904bc2" />

