### PR TITLE
prep v17.0

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chrome-extension",
-  "version": "16.0.0",
+  "version": "17.0.0",
   "private": true,
   "license": "(MIT OR Apache-2.0)",
   "description": "chrome-extension",

--- a/apps/extension/public/beta-manifest.json
+++ b/apps/extension/public/beta-manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Prax wallet BETA",
-  "version": "16.0.0",
+  "version": "17.0.0",
   "description": "THIS EXTENSION IS FOR BETA TESTING",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAhxDXNrlRB72kw+MeeofiBvJuuSkcMI+ZshYS9jve+Zhm0YlYUF/3mriz1D7jdK/U11EjKYMYCTQQEDLmSdQ8Q52ur3ei4u4gjyEpl/+QnjciR7msoziKH48Bia1U+wd53eW3TWNP/vpSJiBsAfOisEPox6w4lC5a03aCXV3xtkzfW0rebZrOLf1xhZD8mc4N9LU289E3cYRlBmfI4qxkBM1r7t9N4KsXle3VWXSn18joKzgzAWK+VhZtZu3xrwMQGpUqn+KyYFvawSGmYdDsnT6y0KS96V3CPp6rQHNfjItB/F4d1JQv1tskc959jiK9CuGbU57D9JHJ+1C9aOb0BwIDAQAB",
   "minimum_chrome_version": "119",

--- a/apps/extension/public/manifest.json
+++ b/apps/extension/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Prax wallet",
-  "version": "16.0.0",
+  "version": "17.0.0",
   "description": "For use in interacting with the Penumbra blockchain",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvnucOJi878TGZYnTNTrvXd9krAcpSDR/EgHcQhvjNZrKfRRsKA9O0DnbyM492c3hiicYPevRPLPoKsLgVghGDYPr8eNO7ee165keD5XLxq0wpWu14gHEPdQSRNZPLeawLp4s/rUwtzMcxhVIUYYaa2xZri4Tqx9wpR7YR1mQTAL8UsdjyitrnzTM20ciKXq1pd82MU74YaZzrcQCOmcjJtjHFdMEAYme+LuZuEugAgef9RiE/8kLQ6T7W9feYfQOky1OPjBkflpRXRgW6cACdl+MeYhKJCOHijglFsPOXX6AvnoJSeAJYRXOMVJi0ejLKEcrLpaeHgh+1WXUvc5G4wIDAQAB",
   "minimum_chrome_version": "119",


### PR DESCRIPTION
bumps latest version to `v17.0` – major breaking change that's not backwards compatible

latest npm package deps were already published and updated in https://github.com/prax-wallet/prax/pull/292 and are currently up to date on this release branch