### PR TITLE
Build cycle improvements

### DIFF
--- a/.syncpackrc
+++ b/.syncpackrc
@@ -12,8 +12,7 @@
     "scripts",
     "files",
     "exports",
-    "publishConfig",
-    "pnpm"
+    "publishConfig"
   ],
   "dependencyTypes": [
     "dev",

--- a/apps/extension/webpack.config.ts
+++ b/apps/extension/webpack.config.ts
@@ -94,7 +94,7 @@ export default ({
               // --ignore-scripts because syncpack doesn't like to run under
               // webpack for some reason. watch out for post-install scripts that
               // dependencies might need.
-              ['-w', 'install', '--ignore-scripts'],
+              ['-w', 'install', '--ignore-scripts', '--offline'],
               { stdio: 'inherit' },
             );
             pnpmInstall.on('exit', code => {

--- a/apps/extension/webpack.config.ts
+++ b/apps/extension/webpack.config.ts
@@ -228,7 +228,7 @@ export default ({
       // watch tarballs for changes
       WEBPACK_WATCH && new WatchExternalFilesPlugin({ files: localPackages }),
       WEBPACK_WATCH && PnpmInstallPlugin,
-      CHROMIUM_PROFILE && WebExtReloadPlugin,
+      WEBPACK_WATCH && CHROMIUM_PROFILE && WebExtReloadPlugin,
     ],
     experiments: {
       asyncWebAssembly: true,

--- a/scripts/add-tgz.ts
+++ b/scripts/add-tgz.ts
@@ -65,4 +65,4 @@ for (const [name, tarballUrl] of Object.entries(overrides)) {
   await cmd('pnpm', ['pkg', 'set', `pnpm.peerDependencyRules.allowAny[].=${name}`]);
 }
 
-await cmd('pnpm', ['install']);
+await cmd('pnpm', ['install', '--offline']);


### PR DESCRIPTION
don't fetch packages during tgz install. this is nice for offline devleopment, as the build iteration doesn't spend time waiting on the network.

syncpack no longer cares about sort location of pnpm field in package json, which add:tgz creates in the 'wrong' place

webpack now only launches chrome when in watch mode, so if a CHROMIUM_PROFILE var is set ambiently, it's not always trying to open chrome.