### PR TITLE
refactor: popup slices use promises to respond

### DIFF
--- a/apps/extension/src/entry/popup-root.tsx
+++ b/apps/extension/src/entry/popup-root.tsx
@@ -22,6 +22,23 @@ const listenPopup = (
   if (isPopupRequest(req)) {
     chrome.runtime.onMessage.removeListener(listenPopup);
     void (async () => {
+      document.addEventListener(
+        /** @see https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilitychange_event */
+        'visibilitychange',
+        () => {
+          if (document.visibilityState === 'hidden') {
+            window.close();
+          }
+        },
+      );
+
+      // Navigation API is available in chrome, but not yet typed.
+      (window as typeof window & { navigation: EventTarget }).navigation.addEventListener(
+        /** @see https://developer.mozilla.org/en-US/docs/Web/API/Navigation/navigate_event */
+        'navigate',
+        () => window.close(),
+      );
+
       try {
         if (isTxApprovalRequest(req)) {
           responder(await txApprovalSelector(useStore.getState()).acceptRequest(req));

--- a/apps/extension/src/state/index.ts
+++ b/apps/extension/src/state/index.ts
@@ -45,7 +45,7 @@ export const initializeStore = (
     network: createNetworkSlice(local)(setState, getState, store),
     numeraires: createNumerairesSlice(local)(setState, getState, store),
     connectedSites: createConnectedSitesSlice(local)(setState, getState, store),
-    txApproval: createTxApprovalSlice()(setState, getState, store),
+    txApproval: createTxApprovalSlice(local)(setState, getState, store),
     originApproval: createOriginApprovalSlice()(setState, getState, store),
     defaultFrontend: createDefaultFrontendSlice(local)(setState, getState, store),
   }));

--- a/apps/extension/src/state/origin-approval.test.ts
+++ b/apps/extension/src/state/origin-approval.test.ts
@@ -1,0 +1,187 @@
+import { create, StoreApi, UseBoundStore } from 'zustand';
+import { AllSlices, initializeStore } from '.';
+import { vi, beforeEach, describe, expect, test } from 'vitest';
+import { mockLocalExtStorage, mockSessionExtStorage } from '../storage/mock';
+import { UserChoice } from '@penumbra-zone/types/user-choice';
+import { OriginApproval, PopupType } from '../message/popup';
+import { InternalResponse } from '@penumbra-zone/types/internal-msg/shared';
+
+describe('Origin Approval Slice', () => {
+  let useStore: UseBoundStore<StoreApi<AllSlices>>;
+
+  let sliceResponse: Promise<InternalResponse<OriginApproval>>;
+  let sendResponse: (r: InternalResponse<OriginApproval>) => void;
+
+  beforeEach(() => {
+    useStore = create<AllSlices>()(initializeStore(mockSessionExtStorage(), mockLocalExtStorage()));
+
+    const slicePromise = Promise.withResolvers<InternalResponse<OriginApproval>>();
+    sliceResponse = slicePromise.promise;
+    sendResponse = slicePromise.resolve;
+  });
+
+  test('initial state is empty', () => {
+    const state = useStore.getState().originApproval;
+    expect(state.responder).toBeUndefined();
+    expect(state.favIconUrl).toBeUndefined();
+    expect(state.title).toBeUndefined();
+    expect(state.requestOrigin).toBeUndefined();
+    expect(state.choice).toBeUndefined();
+    expect(state.lastRequest).toBeUndefined();
+  });
+
+  describe('acceptRequest()', () => {
+    test('accepts a request and sets state correctly', () => {
+      const origin = 'https://example.com';
+      const favIconUrl = 'https://example.com/favicon.ico';
+      const title = 'Example Site';
+      const lastRequest = Date.now();
+
+      useStore.getState().originApproval.acceptRequest(
+        {
+          type: PopupType.OriginApproval,
+          request: {
+            origin,
+            favIconUrl,
+            title,
+            lastRequest,
+          },
+        },
+        sendResponse,
+      );
+
+      // Check state was updated
+      const state = useStore.getState().originApproval;
+      expect(state.responder).not.toBeUndefined();
+      expect(state.favIconUrl).toBe(favIconUrl);
+      expect(state.title).toBe(title);
+      expect(state.requestOrigin).toBe(origin);
+      expect(state.lastRequest?.getTime()).toBe(lastRequest);
+    });
+
+    test('does not set title if it is equal to origin', () => {
+      const origin = 'https://example.com';
+
+      useStore.getState().originApproval.acceptRequest(
+        {
+          type: PopupType.OriginApproval,
+          request: {
+            origin,
+            title: origin,
+          },
+        },
+        sendResponse,
+      );
+
+      // Title should be undefined since it starts with the origin
+      expect(useStore.getState().originApproval.title).toBeUndefined();
+    });
+
+    test('throws if another request is pending', () => {
+      // First request
+      useStore.getState().originApproval.acceptRequest(
+        {
+          type: PopupType.OriginApproval,
+          request: {
+            origin: 'https://example.com',
+          },
+        },
+        sendResponse,
+      );
+
+      // Second request should throw
+      expect(() =>
+        useStore.getState().originApproval.acceptRequest(
+          {
+            type: PopupType.OriginApproval,
+            request: {
+              origin: 'https://another.com',
+            },
+          },
+          sendResponse,
+        ),
+      ).toThrow('Another request is still pending');
+    });
+  });
+
+  describe('setChoice()', () => {
+    test('sets choice correctly', () => {
+      useStore.getState().originApproval.setChoice(UserChoice.Approved);
+      expect(useStore.getState().originApproval.choice).toBe(UserChoice.Approved);
+
+      useStore.getState().originApproval.setChoice(UserChoice.Denied);
+      expect(useStore.getState().originApproval.choice).toBe(UserChoice.Denied);
+    });
+  });
+
+  describe('sendResponse()', () => {
+    test('sends response and resets state', async () => {
+      const origin = 'https://example.com';
+      const date = 1234;
+      vi.setSystemTime(date);
+
+      // Setup - accept a request and set choice
+      useStore.getState().originApproval.acceptRequest(
+        {
+          type: PopupType.OriginApproval,
+          request: {
+            origin,
+          },
+        },
+        sendResponse,
+      );
+
+      // Set the required data
+      useStore.getState().originApproval.setChoice(UserChoice.Approved);
+
+      // Send response
+      useStore.getState().originApproval.sendResponse();
+
+      await expect(sliceResponse).resolves.toMatchObject({
+        type: PopupType.OriginApproval,
+        data: {
+          origin,
+          choice: UserChoice.Approved,
+          date,
+        },
+      });
+
+      // State should be reset
+      const state = useStore.getState().originApproval;
+      expect(state.responder).toBeUndefined();
+      expect(state.favIconUrl).toBeUndefined();
+      expect(state.title).toBeUndefined();
+      expect(state.requestOrigin).toBeUndefined();
+      expect(state.choice).toBeUndefined();
+    });
+
+    test('throws if no responder', () => {
+      expect(() => useStore.getState().originApproval.sendResponse()).toThrow('No responder');
+    });
+
+    test('rejects if missing response data', async () => {
+      // Setup - accept a request but don't set choice
+      useStore.getState().originApproval.acceptRequest(
+        {
+          type: PopupType.OriginApproval,
+          request: {
+            origin: 'https://example.com',
+          },
+        },
+        sendResponse,
+      );
+
+      useStore.getState().originApproval.sendResponse();
+
+      // Send response without choice should throw
+      await expect(sliceResponse).resolves.toMatchObject({
+        type: PopupType.OriginApproval,
+        error: { message: 'Missing response data' },
+      });
+
+      // State should be reset
+      const state = useStore.getState().originApproval;
+      expect(state.responder).toBeUndefined();
+    });
+  });
+});

--- a/apps/extension/src/state/tx-approval.test.ts
+++ b/apps/extension/src/state/tx-approval.test.ts
@@ -1,0 +1,266 @@
+import { JsonObject } from '@bufbuild/protobuf';
+import {
+  TransactionPlan,
+  TransactionView,
+} from '@penumbra-zone/protobuf/penumbra/core/transaction/v1/transaction_pb';
+import { AuthorizeRequest } from '@penumbra-zone/protobuf/penumbra/custody/v1/custody_pb';
+import { UserChoice } from '@penumbra-zone/types/user-choice';
+import { beforeEach, describe, expect, MockedFunction, test, vi } from 'vitest';
+import { create, StoreApi, UseBoundStore } from 'zustand';
+import { AllSlices, initializeStore } from '.';
+import { mockLocalExtStorage, mockSessionExtStorage } from '../storage/mock';
+import { fullViewingKeyFromBech32m } from '@penumbra-zone/bech32m/penumbrafullviewingkey';
+import { FullViewingKey } from '@penumbra-zone/protobuf/penumbra/core/keys/v1/keys_pb';
+import { InternalResponse } from '@penumbra-zone/types/internal-msg/shared';
+import { PopupType, TxApproval } from '../message/popup';
+
+// Mock transaction view functions
+vi.mock('@penumbra-zone/perspective/plan/view-transaction-plan', () => {
+  const viewTransactionPlan: MockedFunction<
+    typeof import('@penumbra-zone/perspective/plan/view-transaction-plan').viewTransactionPlan
+  > = vi.fn((..._) => Promise.resolve(new TransactionView()));
+  return Promise.resolve({ viewTransactionPlan });
+});
+
+// Mock viewClient methods
+vi.mock('../clients', () => ({
+  viewClient: {
+    assetMetadataById: vi.fn().mockResolvedValue({ denomMetadata: null }),
+    indexByAddress: vi.fn().mockResolvedValue({ addressIndex: '1' }),
+  },
+}));
+
+vi.mock('@penumbra-zone/perspective/transaction/classify', () => ({
+  classifyTransaction: vi.fn().mockReturnValue({ type: 'send' }),
+}));
+
+vi.mock('@penumbra-zone/perspective/translators/transaction-view', () => ({
+  asPublicTransactionView: vi.fn().mockReturnValue(new TransactionView({})),
+  asReceiverTransactionView: vi.fn().mockResolvedValue(new TransactionView({})),
+}));
+
+const bech32FVK =
+  'penumbrafullviewingkey1vzfytwlvq067g2kz095vn7sgcft47hga40atrg5zu2crskm6tyyjysm28qg5nth2fqmdf5n0q530jreumjlsrcxjwtfv6zdmfpe5kqsa5lg09';
+
+const wallet0 = {
+  label: 'mock',
+  id: 'mock',
+  fullViewingKey: new FullViewingKey(fullViewingKeyFromBech32m(bech32FVK)).toJsonString(),
+  custody: {
+    encryptedSeedPhrase: {
+      cipherText:
+        'di37XH8dpSbuBN9gwGB6hgAJycWVqozf3UB6O3mKTtimp8DsC0ZZRNEaf1hNi2Eu2pu1dF1f+vHAnisk3W4mRggAVUNtO0gvD8jcM0RhzGVEZnUlZuRR1TtoQDFXzmo=',
+      nonce: 'MUyDW2GHSeZYVF4f',
+    },
+  },
+};
+
+const pw = {
+  _inner: {
+    alg: 'A256GCM',
+    ext: true,
+    k: '2l2K1HKpGWaOriS58zwdDTwAMtMuczuUQc4IYzGxyhM',
+    kty: 'oct',
+    key_ops: ['encrypt', 'decrypt'],
+  },
+};
+
+describe('Transaction Approval Slice', () => {
+  const sessionExtStorage = mockSessionExtStorage();
+  const localExtStorage = mockLocalExtStorage();
+
+  let useStore: UseBoundStore<StoreApi<AllSlices>>;
+
+  let sliceResponse: Promise<InternalResponse<TxApproval>>;
+  let sendResponse: (r: InternalResponse<TxApproval>) => void;
+
+  let authorizeRequest: AuthorizeRequest;
+
+  beforeEach(async () => {
+    await localExtStorage.set('wallets', [wallet0]);
+    await sessionExtStorage.set('passwordKey', pw);
+    useStore = create<AllSlices>()(initializeStore(sessionExtStorage, localExtStorage));
+    vi.clearAllMocks();
+
+    const slicePromise = Promise.withResolvers<InternalResponse<TxApproval>>();
+    sliceResponse = slicePromise.promise;
+    sendResponse = slicePromise.resolve;
+
+    authorizeRequest = new AuthorizeRequest({
+      plan: new TransactionPlan(),
+    });
+  });
+
+  test('initial state is empty', () => {
+    const state = useStore.getState().txApproval;
+    expect(state.responder).toBeUndefined();
+    expect(state.authorizeRequest).toBeUndefined();
+    expect(state.transactionView).toBeUndefined();
+    expect(state.choice).toBeUndefined();
+    expect(state.asSender).toBeUndefined();
+    expect(state.asReceiver).toBeUndefined();
+    expect(state.asPublic).toBeUndefined();
+    expect(state.transactionClassification).toBeUndefined();
+  });
+
+  describe('acceptRequest()', () => {
+    test('throws if no wallet', async () => {
+      await localExtStorage.set('wallets', []);
+
+      await expect(() =>
+        useStore.getState().txApproval.acceptRequest(
+          {
+            type: PopupType.TxApproval,
+            request: {
+              authorizeRequest: authorizeRequest.toJson() as JsonObject,
+            },
+          },
+          sendResponse,
+        ),
+      ).rejects.toThrowError('No found wallet');
+    });
+
+    test('accepts a request and sets state correctly', async () => {
+      await useStore.getState().txApproval.acceptRequest(
+        {
+          type: PopupType.TxApproval,
+          request: {
+            authorizeRequest: authorizeRequest.toJson() as JsonObject,
+          },
+        },
+        sendResponse,
+      );
+
+      expect(useStore.getState().txApproval.authorizeRequest).toEqual(
+        authorizeRequest.toJsonString(),
+      );
+    });
+
+    test('throws if another request is pending', async () => {
+      // First request
+      await useStore.getState().txApproval.acceptRequest(
+        {
+          type: PopupType.TxApproval,
+          request: {
+            authorizeRequest: authorizeRequest.toJson() as JsonObject,
+          },
+        },
+        sendResponse,
+      );
+
+      // Second request should throw
+      await expect(
+        useStore.getState().txApproval.acceptRequest(
+          {
+            type: PopupType.TxApproval,
+            request: {
+              authorizeRequest: authorizeRequest.toJson() as JsonObject,
+            },
+          },
+          vi.fn(),
+        ),
+      ).rejects.toThrow('Another request is still pending');
+    });
+  });
+
+  describe('setChoice()', () => {
+    test('sets choice correctly', async () => {
+      await useStore.getState().txApproval.acceptRequest(
+        {
+          type: PopupType.TxApproval,
+          request: {
+            authorizeRequest: authorizeRequest.toJson() as JsonObject,
+          },
+        },
+        sendResponse,
+      );
+
+      useStore.getState().txApproval.setChoice(UserChoice.Approved);
+      expect(useStore.getState().txApproval.choice).toBe(UserChoice.Approved);
+
+      useStore.getState().txApproval.setChoice(UserChoice.Denied);
+      expect(useStore.getState().txApproval.choice).toBe(UserChoice.Denied);
+    });
+  });
+
+  describe('sendResponse()', () => {
+    test('throws if no responder', () => {
+      expect(() => useStore.getState().txApproval.sendResponse()).toThrow('No responder');
+    });
+
+    test('resets state after sending response', async () => {
+      const authorizeRequest = new AuthorizeRequest({
+        plan: new TransactionPlan(),
+      });
+
+      // Setup - accept a request and set choice
+      await useStore.getState().txApproval.acceptRequest(
+        {
+          type: PopupType.TxApproval,
+          request: {
+            authorizeRequest: authorizeRequest.toJson() as JsonObject,
+          },
+        },
+        sendResponse,
+      );
+
+      // Set the choice
+      useStore.getState().txApproval.setChoice(UserChoice.Approved);
+
+      // Send response
+      useStore.getState().txApproval.sendResponse();
+
+      await expect(sliceResponse).resolves.toMatchObject({
+        type: PopupType.TxApproval,
+        data: {
+          authorizeRequest: authorizeRequest.toJson(),
+          choice: UserChoice.Approved,
+        },
+      });
+
+      // State should be reset
+      const state = useStore.getState().txApproval;
+      expect(state.responder).toBeUndefined();
+      expect(state.authorizeRequest).toBeUndefined();
+      expect(state.transactionView).toBeUndefined();
+      expect(state.choice).toBeUndefined();
+      expect(state.asSender).toBeUndefined();
+      expect(state.asReceiver).toBeUndefined();
+      expect(state.asPublic).toBeUndefined();
+      expect(state.transactionClassification).toBeUndefined();
+    });
+
+    test('rejects if missing response data', async () => {
+      const authorizeRequest = new AuthorizeRequest({
+        plan: new TransactionPlan(),
+      });
+
+      // Setup - accept a request but don't set choice
+      await useStore.getState().txApproval.acceptRequest(
+        {
+          type: PopupType.TxApproval,
+          request: {
+            authorizeRequest: authorizeRequest.toJson() as JsonObject,
+          },
+        },
+        sendResponse,
+      );
+
+      // Should throw when sending response without setting choice
+      expect(() => useStore.getState().txApproval.sendResponse()).not.toThrow();
+      await expect(sliceResponse).resolves.toMatchObject({
+        type: PopupType.TxApproval,
+        error: {
+          message: 'Missing response data',
+        },
+      });
+
+      // State should be reset after throwing
+      const state = useStore.getState().txApproval;
+      expect(state.responder).toBeUndefined();
+      expect(state.authorizeRequest).toBeUndefined();
+      expect(state.transactionView).toBeUndefined();
+      expect(state.choice).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
instead of handling message responders directly, popup slices simply provide a promise for their result. the responder function remains within the message listener scope.

tests are added to confirm functionality in the slices, then the change is implemented.