### PR TITLE
synpack deps

### DIFF
--- a/.syncpackrc
+++ b/.syncpackrc
@@ -43,15 +43,16 @@
   ],
   "versionGroups": [
     {
-      "label": "Ensure @bufbuild and @connectrpc don't upgrade yet",
-      "packages": [
-        "**"
-      ],
-      "dependencies": [
-        "@bufbuild/**",
-        "@connectrpc/**"
-      ],
-      "pinVersion": "^1.x"
+      "label": "Pin @connectrpc for compatibility",
+      "packages": ["**"],
+      "dependencies": ["@connectrpc/**"],
+      "pinVersion": "^1.6.1"
+    },
+    {
+      "label": "Pin @bufbuild for compatibility",
+      "packages": ["**"],
+      "dependencies": ["@bufbuild/**"],
+      "pinVersion": "^1.10.0"
     },
     {
       "label": "Use workspace protocol for local packages",

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -15,9 +15,9 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@bufbuild/protobuf": "^1.x",
-    "@connectrpc/connect": "^1.x",
-    "@connectrpc/connect-web": "^1.x",
+    "@bufbuild/protobuf": "^1.10.0",
+    "@connectrpc/connect": "^1.6.1",
+    "@connectrpc/connect-web": "^1.6.1",
     "@penumbra-labs/registry": "^12.4.0",
     "@penumbra-zone/bech32m": "15.0.0",
     "@penumbra-zone/client": "26.0.0",

--- a/apps/extension/src/clients.ts
+++ b/apps/extension/src/clients.ts
@@ -1,5 +1,5 @@
 import { ViewService } from '@penumbra-zone/protobuf';
-import { createPromiseClient } from '@connectrpc/connect';
+import { createClient } from '@connectrpc/connect';
 import { createChannelTransport } from '@penumbra-zone/transport-dom/create';
 import { CRSessionClient } from '@penumbra-zone/transport-chrome/session-client';
 import { internalTransportOptions } from './transport-options';
@@ -11,4 +11,4 @@ const extensionPageTransport = createChannelTransport({
   getPort: () => Promise.resolve(port),
 });
 
-export const viewClient = createPromiseClient(ViewService, extensionPageTransport);
+export const viewClient = createClient(ViewService, extensionPageTransport);

--- a/apps/extension/src/hooks/latest-block-height.ts
+++ b/apps/extension/src/hooks/latest-block-height.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { sample } from 'lodash';
-import { createPromiseClient, Transport } from '@connectrpc/connect';
+import { createClient, Transport } from '@connectrpc/connect';
 import { createGrpcWebTransport } from '@connectrpc/connect-web';
 import { TendermintProxyService } from '@penumbra-zone/protobuf';
 import { useStore } from '../state';
@@ -42,7 +42,7 @@ export const fetchBlockHeightWithTimeout = async (
   transport = createGrpcWebTransport({ baseUrl: grpcEndpoint }),
   timeoutMs = 3000,
 ): Promise<number> => {
-  const tendermintClient = createPromiseClient(TendermintProxyService, transport);
+  const tendermintClient = createClient(TendermintProxyService, transport);
 
   const result = await tendermintClient.getStatus({}, { signal: AbortSignal.timeout(timeoutMs) });
   if (!result.syncInfo) {
@@ -53,7 +53,7 @@ export const fetchBlockHeightWithTimeout = async (
 
 // Fetch the block height from a specific RPC endpoint.
 export const fetchBlockHeight = async (grpcEndpoint: string): Promise<number> => {
-  const tendermintClient = createPromiseClient(
+  const tendermintClient = createClient(
     TendermintProxyService,
     createGrpcWebTransport({ baseUrl: grpcEndpoint }),
   );

--- a/apps/extension/src/routes/page/onboarding/password/utils.ts
+++ b/apps/extension/src/routes/page/onboarding/password/utils.ts
@@ -4,7 +4,7 @@ import { PagePath } from '../../paths';
 import { usePageNav } from '../../../../utils/navigate';
 import { ChainRegistryClient, EntityMetadata } from '@penumbra-labs/registry';
 import { sample } from 'lodash';
-import { createPromiseClient } from '@connectrpc/connect';
+import { createClient } from '@connectrpc/connect';
 import { createGrpcWebTransport } from '@connectrpc/connect-web';
 import { localExtStorage } from '../../../../storage/local';
 import { AppService } from '@penumbra-zone/protobuf';
@@ -54,7 +54,7 @@ export const setOnboardingValuesInStorage = async (seedPhraseOrigin: SEED_PHRASE
   // Queries for blockHeight regardless of SEED_PHRASE_ORIGIN as a means of testing endpoint for liveness
   const { blockHeight, rpc } = await fetchBlockHeightWithFallback(rpcs.map(r => r.url));
 
-  const { appParameters } = await createPromiseClient(
+  const { appParameters } = await createClient(
     AppService,
     createGrpcWebTransport({ baseUrl: rpc }),
   ).appParameters({}, DEFAULT_TRANSPORT_OPTS);

--- a/apps/extension/src/rpc/index.ts
+++ b/apps/extension/src/rpc/index.ts
@@ -45,11 +45,7 @@ export const getRpcImpls = async () => {
     serviceType =>
       [
         serviceType,
-        createProxyImpl(
-          serviceType,
-          createClient(serviceType, webTransport),
-          noContextHandler,
-        ),
+        createProxyImpl(serviceType, createClient(serviceType, webTransport), noContextHandler),
       ] as const,
   );
 

--- a/apps/extension/src/rpc/index.ts
+++ b/apps/extension/src/rpc/index.ts
@@ -1,6 +1,6 @@
 import type { ServiceType } from '@bufbuild/protobuf';
 import type { ServiceImpl } from '@connectrpc/connect';
-import { createPromiseClient } from '@connectrpc/connect';
+import { createClient } from '@connectrpc/connect';
 import { createGrpcWebTransport } from '@connectrpc/connect-web';
 import {
   AppService,
@@ -47,7 +47,7 @@ export const getRpcImpls = async () => {
         serviceType,
         createProxyImpl(
           serviceType,
-          createPromiseClient(serviceType, webTransport),
+          createClient(serviceType, webTransport),
           noContextHandler,
         ),
       ] as const,
@@ -66,7 +66,7 @@ export const getRpcImpls = async () => {
         TendermintProxyService,
         createProxyImpl(
           TendermintProxyService,
-          createPromiseClient(TendermintProxyService, webTransport),
+          createClient(TendermintProxyService, webTransport),
           noContextHandler,
         ),
       ),

--- a/apps/extension/src/service-worker.ts
+++ b/apps/extension/src/service-worker.ts
@@ -15,7 +15,7 @@ import './listeners';
 import { getRpcImpls } from './rpc';
 
 // adapter
-import { ConnectRouter, createContextValues, PromiseClient } from '@connectrpc/connect';
+import { ConnectRouter, createContextValues, Client } from '@connectrpc/connect';
 import { jsonOptions } from '@penumbra-zone/protobuf';
 import { CRSessionManager } from '@penumbra-zone/transport-chrome/session-manager';
 import { connectChannelAdapter } from '@penumbra-zone/transport-dom/adapter';
@@ -48,8 +48,8 @@ const initHandler = async () => {
   const walletServices = startWalletServices();
   const rpcImpls = await getRpcImpls();
 
-  let custodyClient: PromiseClient<typeof CustodyService> | undefined;
-  let stakeClient: PromiseClient<typeof StakeService> | undefined;
+  let custodyClient: Client<typeof CustodyService> | undefined;
+  let stakeClient: Client<typeof StakeService> | undefined;
 
   return connectChannelAdapter({
     jsonOptions,

--- a/apps/extension/src/shared/components/grpc-endpoint-form/use-grpc-endpoint-form.ts
+++ b/apps/extension/src/shared/components/grpc-endpoint-form/use-grpc-endpoint-form.ts
@@ -1,4 +1,4 @@
-import { Code, ConnectError, createPromiseClient } from '@connectrpc/connect';
+import { Code, ConnectError, createClient } from '@connectrpc/connect';
 import { AppService } from '@penumbra-zone/protobuf';
 import { createGrpcWebTransport } from '@connectrpc/connect-web';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -67,7 +67,7 @@ export const useGrpcEndpointForm = (isOnboarding: boolean) => {
 
       try {
         setIsValidationLoading(true);
-        const trialClient = createPromiseClient(
+        const trialClient = createClient(
           AppService,
           createGrpcWebTransport({ baseUrl: grpcEndpointInput }),
         );

--- a/apps/extension/src/wallet-services.ts
+++ b/apps/extension/src/wallet-services.ts
@@ -1,7 +1,7 @@
 import { AppParameters } from '@penumbra-zone/protobuf/penumbra/core/app/v1/app_pb';
 import { AppService } from '@penumbra-zone/protobuf';
 import { createGrpcWebTransport } from '@connectrpc/connect-web';
-import { createPromiseClient } from '@connectrpc/connect';
+import { createClient } from '@connectrpc/connect';
 import { FullViewingKey, WalletId } from '@penumbra-zone/protobuf/penumbra/core/keys/v1/keys_pb';
 import { localExtStorage } from './storage/local';
 import { onboardGrpcEndpoint, onboardWallet } from './storage/onboard';
@@ -41,7 +41,7 @@ export const startWalletServices = async () => {
  * @see https://github.com/prax-wallet/prax/pull/65
  */
 const getChainId = async (baseUrl: string) => {
-  const serviceClient = createPromiseClient(AppService, createGrpcWebTransport({ baseUrl }));
+  const serviceClient = createClient(AppService, createGrpcWebTransport({ baseUrl }));
   const params =
     (await serviceClient.appParameters({}).then(
       ({ appParameters }) => appParameters,

--- a/docs/extension-services.md
+++ b/docs/extension-services.md
@@ -62,7 +62,7 @@ const channelTransport = createChannelTransport({
   jsonOptions: { typeRegistry: createRegistry(ViewService) },
 });
 
-const viewClient = createPromiseClient(ViewService, channelTransport);
+const viewClient = createClient(ViewService, channelTransport);
 const { address } = await viewClient.addressByIndex({});
 console.log(bech32mAddress(address));
 ```

--- a/package.json
+++ b/package.json
@@ -52,5 +52,37 @@
     "typescript": "^5.5.4",
     "typescript-eslint": "^8.16.0",
     "vitest": "1.x"
+  },
+  "pnpm": {
+    "overrides": {
+      "@penumbra-zone/bech32m": "file:///Users/margulus/temp-desktop/Programming/Repository/Penumbra/web/packages/bech32m/penumbra-zone-bech32m-15.0.0.tgz",
+      "@penumbra-zone/client": "file:///Users/margulus/temp-desktop/Programming/Repository/Penumbra/web/packages/client/penumbra-zone-client-26.0.0.tgz",
+      "@penumbra-zone/crypto-web": "file:///Users/margulus/temp-desktop/Programming/Repository/Penumbra/web/packages/crypto/penumbra-zone-crypto-web-39.0.0.tgz",
+      "@penumbra-zone/getters": "file:///Users/margulus/temp-desktop/Programming/Repository/Penumbra/web/packages/getters/penumbra-zone-getters-25.0.0.tgz",
+      "@penumbra-zone/perspective": "file:///Users/margulus/temp-desktop/Programming/Repository/Penumbra/web/packages/perspective/penumbra-zone-perspective-51.0.0.tgz",
+      "@penumbra-zone/protobuf": "file:///Users/margulus/temp-desktop/Programming/Repository/Penumbra/web/packages/protobuf/penumbra-zone-protobuf-9.0.0.tgz",
+      "@penumbra-zone/services": "file:///Users/margulus/temp-desktop/Programming/Repository/Penumbra/web/packages/services/penumbra-zone-services-57.0.0.tgz",
+      "@penumbra-zone/storage": "file:///Users/margulus/temp-desktop/Programming/Repository/Penumbra/web/packages/storage/penumbra-zone-storage-51.0.0.tgz",
+      "@penumbra-zone/transport-chrome": "file:///Users/margulus/temp-desktop/Programming/Repository/Penumbra/web/packages/transport-chrome/penumbra-zone-transport-chrome-9.0.0.tgz",
+      "@penumbra-zone/transport-dom": "file:///Users/margulus/temp-desktop/Programming/Repository/Penumbra/web/packages/transport-dom/penumbra-zone-transport-dom-7.5.1.tgz",
+      "@penumbra-zone/types": "file:///Users/margulus/temp-desktop/Programming/Repository/Penumbra/web/packages/types/penumbra-zone-types-32.0.0.tgz",
+      "@penumbra-zone/wasm": "file:///Users/margulus/temp-desktop/Programming/Repository/Penumbra/web/packages/wasm/penumbra-zone-wasm-43.1.0.tgz"
+    },
+    "peerDependencyRules": {
+      "allowAny": [
+        "@penumbra-zone/bech32m",
+        "@penumbra-zone/client",
+        "@penumbra-zone/crypto-web",
+        "@penumbra-zone/getters",
+        "@penumbra-zone/perspective",
+        "@penumbra-zone/protobuf",
+        "@penumbra-zone/services",
+        "@penumbra-zone/storage",
+        "@penumbra-zone/transport-chrome",
+        "@penumbra-zone/transport-dom",
+        "@penumbra-zone/types",
+        "@penumbra-zone/wasm"
+      ]
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -52,37 +52,5 @@
     "typescript": "^5.5.4",
     "typescript-eslint": "^8.16.0",
     "vitest": "1.x"
-  },
-  "pnpm": {
-    "overrides": {
-      "@penumbra-zone/bech32m": "file:///Users/margulus/temp-desktop/Programming/Repository/Penumbra/web/packages/bech32m/penumbra-zone-bech32m-15.0.0.tgz",
-      "@penumbra-zone/client": "file:///Users/margulus/temp-desktop/Programming/Repository/Penumbra/web/packages/client/penumbra-zone-client-26.0.0.tgz",
-      "@penumbra-zone/crypto-web": "file:///Users/margulus/temp-desktop/Programming/Repository/Penumbra/web/packages/crypto/penumbra-zone-crypto-web-39.0.0.tgz",
-      "@penumbra-zone/getters": "file:///Users/margulus/temp-desktop/Programming/Repository/Penumbra/web/packages/getters/penumbra-zone-getters-25.0.0.tgz",
-      "@penumbra-zone/perspective": "file:///Users/margulus/temp-desktop/Programming/Repository/Penumbra/web/packages/perspective/penumbra-zone-perspective-51.0.0.tgz",
-      "@penumbra-zone/protobuf": "file:///Users/margulus/temp-desktop/Programming/Repository/Penumbra/web/packages/protobuf/penumbra-zone-protobuf-9.0.0.tgz",
-      "@penumbra-zone/services": "file:///Users/margulus/temp-desktop/Programming/Repository/Penumbra/web/packages/services/penumbra-zone-services-57.0.0.tgz",
-      "@penumbra-zone/storage": "file:///Users/margulus/temp-desktop/Programming/Repository/Penumbra/web/packages/storage/penumbra-zone-storage-51.0.0.tgz",
-      "@penumbra-zone/transport-chrome": "file:///Users/margulus/temp-desktop/Programming/Repository/Penumbra/web/packages/transport-chrome/penumbra-zone-transport-chrome-9.0.0.tgz",
-      "@penumbra-zone/transport-dom": "file:///Users/margulus/temp-desktop/Programming/Repository/Penumbra/web/packages/transport-dom/penumbra-zone-transport-dom-7.5.1.tgz",
-      "@penumbra-zone/types": "file:///Users/margulus/temp-desktop/Programming/Repository/Penumbra/web/packages/types/penumbra-zone-types-32.0.0.tgz",
-      "@penumbra-zone/wasm": "file:///Users/margulus/temp-desktop/Programming/Repository/Penumbra/web/packages/wasm/penumbra-zone-wasm-43.1.0.tgz"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "@penumbra-zone/bech32m",
-        "@penumbra-zone/client",
-        "@penumbra-zone/crypto-web",
-        "@penumbra-zone/getters",
-        "@penumbra-zone/perspective",
-        "@penumbra-zone/protobuf",
-        "@penumbra-zone/services",
-        "@penumbra-zone/storage",
-        "@penumbra-zone/transport-chrome",
-        "@penumbra-zone/transport-dom",
-        "@penumbra-zone/types",
-        "@penumbra-zone/wasm"
-      ]
-    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
     "zip": "pnpm tsx apps/extension/src/utils/zip-extension.ts"
   },
   "dependencies": {
-    "@bufbuild/protobuf": "^1.x",
-    "@connectrpc/connect": "^1.x",
-    "@connectrpc/connect-web": "^1.x"
+    "@bufbuild/protobuf": "^1.10.0",
+    "@connectrpc/connect": "^1.6.1",
+    "@connectrpc/connect-web": "^1.6.1"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.11",

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -16,7 +16,7 @@
     ".": "./src/index.ts"
   },
   "peerDependencies": {
-    "@bufbuild/protobuf": "^1.x",
+    "@bufbuild/protobuf": "^1.10.0",
     "@penumbra-labs/registry": "^12.4.0",
     "@penumbra-zone/bech32m": "15.0.0",
     "@penumbra-zone/crypto-web": "39.0.0",

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -23,9 +23,9 @@
     }
   },
   "dependencies": {
-    "@bufbuild/protobuf": "^1.x",
-    "@connectrpc/connect": "^1.x",
-    "@connectrpc/connect-web": "^1.x",
+    "@bufbuild/protobuf": "^1.10.0",
+    "@connectrpc/connect": "^1.6.1",
+    "@connectrpc/connect-web": "^1.6.1",
     "@penumbra-zone/bech32m": "15.0.0",
     "@penumbra-zone/crypto-web": "39.0.0",
     "@penumbra-zone/getters": "25.0.0",

--- a/packages/query/src/queriers/app.ts
+++ b/packages/query/src/queriers/app.ts
@@ -1,4 +1,4 @@
-import { PromiseClient } from '@connectrpc/connect';
+import { Client } from '@connectrpc/connect';
 import { createClient } from './utils';
 import { AppParameters } from '@penumbra-zone/protobuf/penumbra/core/app/v1/app_pb';
 import { Transaction } from '@penumbra-zone/protobuf/penumbra/core/transaction/v1/transaction_pb';
@@ -6,7 +6,7 @@ import { AppService } from '@penumbra-zone/protobuf';
 import type { AppQuerierInterface } from '@penumbra-zone/types/querier';
 
 export class AppQuerier implements AppQuerierInterface {
-  private readonly client: PromiseClient<typeof AppService>;
+  private readonly client: Client<typeof AppService>;
 
   constructor({ grpcEndpoint }: { grpcEndpoint: string }) {
     this.client = createClient(grpcEndpoint, AppService);

--- a/packages/query/src/queriers/auction.ts
+++ b/packages/query/src/queriers/auction.ts
@@ -1,6 +1,6 @@
 import { AuctionQuerierInterface } from '@penumbra-zone/types/querier';
 import { AuctionService } from '@penumbra-zone/protobuf';
-import { PromiseClient } from '@connectrpc/connect';
+import { Client } from '@connectrpc/connect';
 import { createClient } from './utils';
 import {
   AuctionId,
@@ -9,7 +9,7 @@ import {
 import { typeUrlMatchesTypeName } from '@penumbra-zone/types/protobuf';
 
 export class AuctionQuerier implements AuctionQuerierInterface {
-  private readonly client: PromiseClient<typeof AuctionService>;
+  private readonly client: Client<typeof AuctionService>;
 
   constructor({ grpcEndpoint }: { grpcEndpoint: string }) {
     this.client = createClient(grpcEndpoint, AuctionService);

--- a/packages/query/src/queriers/cnidarium.ts
+++ b/packages/query/src/queriers/cnidarium.ts
@@ -1,4 +1,4 @@
-import { PromiseClient } from '@connectrpc/connect';
+import { Client } from '@connectrpc/connect';
 import { createClient } from './utils';
 import { CnidariumService } from '@penumbra-zone/protobuf';
 import { KeyValueRequest } from '@penumbra-zone/protobuf/penumbra/cnidarium/v1/cnidarium_pb';
@@ -6,7 +6,7 @@ import { CnidariumQuerierInterface } from '@penumbra-zone/types/querier';
 import { MerkleRoot } from '@penumbra-zone/protobuf/penumbra/crypto/tct/v1/tct_pb';
 
 export class CnidariumQuerier implements CnidariumQuerierInterface {
-  private readonly client: PromiseClient<typeof CnidariumService>;
+  private readonly client: Client<typeof CnidariumService>;
 
   constructor({ grpcEndpoint }: { grpcEndpoint: string }) {
     this.client = createClient(grpcEndpoint, CnidariumService);

--- a/packages/query/src/queriers/compact-block.ts
+++ b/packages/query/src/queriers/compact-block.ts
@@ -1,4 +1,4 @@
-import { PromiseClient } from '@connectrpc/connect';
+import { Client } from '@connectrpc/connect';
 import {
   CompactBlock,
   CompactBlockRangeRequest,
@@ -11,7 +11,7 @@ import type {
 } from '@penumbra-zone/types/querier';
 
 export class CompactBlockQuerier implements CompactBlockQuerierInterface {
-  private readonly client: PromiseClient<typeof CompactBlockService>;
+  private readonly client: Client<typeof CompactBlockService>;
 
   constructor({ grpcEndpoint }: { grpcEndpoint: string }) {
     this.client = createClient(grpcEndpoint, CompactBlockService);

--- a/packages/query/src/queriers/funding.ts
+++ b/packages/query/src/queriers/funding.ts
@@ -1,4 +1,4 @@
-import { PromiseClient } from '@connectrpc/connect';
+import { Client } from '@connectrpc/connect';
 import { createClient } from './utils';
 import { FundingService } from '@penumbra-zone/protobuf';
 import { FundingQuerierInterface } from '@penumbra-zone/types/querier';
@@ -9,7 +9,7 @@ import {
 } from '@penumbra-zone/protobuf/penumbra/core/component/funding/v1/funding_pb';
 
 export class FundingQuerier implements FundingQuerierInterface {
-  private readonly client: PromiseClient<typeof FundingService>;
+  private readonly client: Client<typeof FundingService>;
 
   constructor({ grpcEndpoint }: { grpcEndpoint: string }) {
     this.client = createClient(grpcEndpoint, FundingService);

--- a/packages/query/src/queriers/ibc-client.ts
+++ b/packages/query/src/queriers/ibc-client.ts
@@ -1,4 +1,4 @@
-import { PromiseClient } from '@connectrpc/connect';
+import { Client } from '@connectrpc/connect';
 import { createClient } from './utils';
 import { IbcClientService } from '@penumbra-zone/protobuf';
 import {
@@ -8,7 +8,7 @@ import {
 import type { IbcClientQuerierInterface } from '@penumbra-zone/types/querier';
 
 export class IbcClientQuerier implements IbcClientQuerierInterface {
-  private readonly client: PromiseClient<typeof IbcClientService>;
+  private readonly client: Client<typeof IbcClientService>;
 
   constructor({ grpcEndpoint }: { grpcEndpoint: string }) {
     this.client = createClient(grpcEndpoint, IbcClientService);

--- a/packages/query/src/queriers/sct.ts
+++ b/packages/query/src/queriers/sct.ts
@@ -1,4 +1,4 @@
-import { PromiseClient } from '@connectrpc/connect';
+import { Client } from '@connectrpc/connect';
 import { createClient } from './utils';
 import { SctService } from '@penumbra-zone/protobuf';
 import { SctQuerierInterface } from '@penumbra-zone/types/querier';
@@ -8,7 +8,7 @@ import {
 } from '@penumbra-zone/protobuf/penumbra/core/component/sct/v1/sct_pb';
 
 export class SctQuerier implements SctQuerierInterface {
-  private readonly client: PromiseClient<typeof SctService>;
+  private readonly client: Client<typeof SctService>;
 
   constructor({ grpcEndpoint }: { grpcEndpoint: string }) {
     this.client = createClient(grpcEndpoint, SctService);

--- a/packages/query/src/queriers/shielded-pool.ts
+++ b/packages/query/src/queriers/shielded-pool.ts
@@ -1,4 +1,4 @@
-import { PromiseClient } from '@connectrpc/connect';
+import { Client } from '@connectrpc/connect';
 import { createClient } from './utils';
 import { ShieldedPoolService } from '@penumbra-zone/protobuf';
 import { AssetId, Metadata } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
@@ -10,7 +10,7 @@ declare global {
 }
 
 export class ShieldedPoolQuerier implements ShieldedPoolQuerierInterface {
-  private readonly client: PromiseClient<typeof ShieldedPoolService>;
+  private readonly client: Client<typeof ShieldedPoolService>;
 
   constructor({ grpcEndpoint }: { grpcEndpoint: string }) {
     this.client = createClient(grpcEndpoint, ShieldedPoolService);

--- a/packages/query/src/queriers/staking.ts
+++ b/packages/query/src/queriers/staking.ts
@@ -1,4 +1,4 @@
-import { PromiseClient } from '@connectrpc/connect';
+import { Client } from '@connectrpc/connect';
 import { createClient } from './utils';
 import { StakeService } from '@penumbra-zone/protobuf';
 import {
@@ -11,7 +11,7 @@ import {
 import { StakeQuerierInterface } from '@penumbra-zone/types/querier';
 
 export class StakeQuerier implements StakeQuerierInterface {
-  private readonly client: PromiseClient<typeof StakeService>;
+  private readonly client: Client<typeof StakeService>;
 
   constructor({ grpcEndpoint }: { grpcEndpoint: string }) {
     this.client = createClient(grpcEndpoint, StakeService);

--- a/packages/query/src/queriers/tendermint.ts
+++ b/packages/query/src/queriers/tendermint.ts
@@ -1,4 +1,4 @@
-import { PromiseClient } from '@connectrpc/connect';
+import { Client } from '@connectrpc/connect';
 import { createClient } from './utils';
 import { TendermintProxyService } from '@penumbra-zone/protobuf';
 import { TransactionId } from '@penumbra-zone/protobuf/penumbra/core/txhash/v1/txhash_pb';
@@ -11,7 +11,7 @@ declare global {
 }
 
 export class TendermintQuerier implements TendermintQuerierInterface {
-  private readonly client: PromiseClient<typeof TendermintProxyService>;
+  private readonly client: Client<typeof TendermintProxyService>;
 
   constructor({ grpcEndpoint }: { grpcEndpoint: string }) {
     this.client = createClient(grpcEndpoint, TendermintProxyService);

--- a/packages/query/src/queriers/utils.ts
+++ b/packages/query/src/queriers/utils.ts
@@ -1,11 +1,11 @@
-import { createPromiseClient, PromiseClient } from '@connectrpc/connect';
+import { createClient as createPromiseClient, Client } from '@connectrpc/connect';
 import { createGrpcWebTransport } from '@connectrpc/connect-web';
 import { ServiceType } from '@bufbuild/protobuf';
 
 export const createClient = <T extends ServiceType>(
   grpcEndpoint: string,
   serviceType: T,
-): PromiseClient<T> => {
+): Client<T> => {
   const transport = createGrpcWebTransport({
     baseUrl: grpcEndpoint,
   });

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -71,7 +71,7 @@
     "tinycolor2": "^1.6.0"
   },
   "devDependencies": {
-    "@bufbuild/protobuf": "^1.x",
+    "@bufbuild/protobuf": "^1.10.0",
     "@storybook/addon-essentials": "^8.4.7",
     "@storybook/addon-interactions": "^8.4.7",
     "@storybook/addon-links": "^8.4.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,14 +11,14 @@ importers:
   .:
     dependencies:
       '@bufbuild/protobuf':
-        specifier: ^1.x
+        specifier: ^1.10.0
         version: 1.10.0
       '@connectrpc/connect':
-        specifier: ^1.x
-        version: 1.4.0(@bufbuild/protobuf@1.10.0)
+        specifier: ^1.6.1
+        version: 1.6.1(@bufbuild/protobuf@1.10.0)
       '@connectrpc/connect-web':
-        specifier: ^1.x
-        version: 1.4.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.4.0(@bufbuild/protobuf@1.10.0))
+        specifier: ^1.6.1
+        version: 1.6.1(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.6.1(@bufbuild/protobuf@1.10.0))
     devDependencies:
       '@changesets/cli':
         specifier: ^2.27.11
@@ -78,14 +78,14 @@ importers:
   apps/extension:
     dependencies:
       '@bufbuild/protobuf':
-        specifier: ^1.x
+        specifier: ^1.10.0
         version: 1.10.0
       '@connectrpc/connect':
-        specifier: ^1.x
-        version: 1.4.0(@bufbuild/protobuf@1.10.0)
+        specifier: ^1.6.1
+        version: 1.6.1(@bufbuild/protobuf@1.10.0)
       '@connectrpc/connect-web':
-        specifier: ^1.x
-        version: 1.4.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.4.0(@bufbuild/protobuf@1.10.0))
+        specifier: ^1.6.1
+        version: 1.6.1(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.6.1(@bufbuild/protobuf@1.10.0))
       '@penumbra-labs/registry':
         specifier: ^12.4.0
         version: 12.4.0
@@ -94,7 +94,7 @@ importers:
         version: 15.0.0(@penumbra-zone/protobuf@9.0.0(@bufbuild/protobuf@1.10.0))
       '@penumbra-zone/client':
         specifier: 26.0.0
-        version: 26.0.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.4.0(@bufbuild/protobuf@1.10.0))(@penumbra-zone/protobuf@9.0.0(@bufbuild/protobuf@1.10.0))(@penumbra-zone/transport-dom@7.5.1)
+        version: 26.0.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.6.1(@bufbuild/protobuf@1.10.0))(@penumbra-zone/protobuf@9.0.0(@bufbuild/protobuf@1.10.0))(@penumbra-zone/transport-dom@7.5.1)
       '@penumbra-zone/crypto-web':
         specifier: 39.0.0
         version: 39.0.0(@penumbra-zone/types@32.0.0(@bufbuild/protobuf@1.10.0)(@penumbra-zone/bech32m@15.0.0(@penumbra-zone/protobuf@9.0.0(@bufbuild/protobuf@1.10.0)))(@penumbra-zone/getters@25.0.0(@bufbuild/protobuf@1.10.0)(@penumbra-zone/bech32m@15.0.0(@penumbra-zone/protobuf@9.0.0(@bufbuild/protobuf@1.10.0)))(@penumbra-zone/protobuf@9.0.0(@bufbuild/protobuf@1.10.0)))(@penumbra-zone/protobuf@9.0.0(@bufbuild/protobuf@1.10.0)))
@@ -115,13 +115,13 @@ importers:
         version: link:../../packages/query
       '@penumbra-zone/services':
         specifier: 56.0.0
-        version: 56.0.0(x5cv7ko3dpj5ndqifdtjekdeki)
+        version: 56.0.0(xdxk3yacyqjn4re2ijx75tncgu)
       '@penumbra-zone/storage':
         specifier: 50.0.0
         version: 50.0.0(ntisidl2tqonimxstafetwvn7e)
       '@penumbra-zone/transport-chrome':
         specifier: 9.0.0
-        version: 9.0.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.4.0(@bufbuild/protobuf@1.10.0))(@penumbra-zone/transport-dom@7.5.1)
+        version: 9.0.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.6.1(@bufbuild/protobuf@1.10.0))(@penumbra-zone/transport-dom@7.5.1)
       '@penumbra-zone/transport-dom':
         specifier: 7.5.1
         version: 7.5.1
@@ -253,7 +253,7 @@ importers:
   packages/context:
     dependencies:
       '@bufbuild/protobuf':
-        specifier: ^1.x
+        specifier: ^1.10.0
         version: 1.10.0
       '@penumbra-labs/registry':
         specifier: ^12.4.0
@@ -281,13 +281,13 @@ importers:
         version: link:../query
       '@penumbra-zone/services':
         specifier: 56.0.0
-        version: 56.0.0(x5cv7ko3dpj5ndqifdtjekdeki)
+        version: 56.0.0(xdxk3yacyqjn4re2ijx75tncgu)
       '@penumbra-zone/storage':
         specifier: 50.0.0
         version: 50.0.0(ntisidl2tqonimxstafetwvn7e)
       '@penumbra-zone/transport-chrome':
         specifier: 9.0.0
-        version: 9.0.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.4.0(@bufbuild/protobuf@1.10.0))(@penumbra-zone/transport-dom@7.5.1)
+        version: 9.0.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.6.1(@bufbuild/protobuf@1.10.0))(@penumbra-zone/transport-dom@7.5.1)
       '@penumbra-zone/transport-dom':
         specifier: 7.5.1
         version: 7.5.1
@@ -325,14 +325,14 @@ importers:
   packages/query:
     dependencies:
       '@bufbuild/protobuf':
-        specifier: ^1.x
+        specifier: ^1.10.0
         version: 1.10.0
       '@connectrpc/connect':
-        specifier: ^1.x
-        version: 1.4.0(@bufbuild/protobuf@1.10.0)
+        specifier: ^1.6.1
+        version: 1.6.1(@bufbuild/protobuf@1.10.0)
       '@connectrpc/connect-web':
-        specifier: ^1.x
-        version: 1.4.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.4.0(@bufbuild/protobuf@1.10.0))
+        specifier: ^1.6.1
+        version: 1.6.1(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.6.1(@bufbuild/protobuf@1.10.0))
       '@penumbra-zone/bech32m':
         specifier: 15.0.0
         version: 15.0.0(@penumbra-zone/protobuf@9.0.0(@bufbuild/protobuf@1.10.0))
@@ -496,7 +496,7 @@ importers:
         version: 1.6.0
     devDependencies:
       '@bufbuild/protobuf':
-        specifier: ^1.x
+        specifier: ^1.10.0
         version: 1.10.0
       '@storybook/addon-essentials':
         specifier: ^8.4.7
@@ -756,16 +756,16 @@ packages:
   '@confio/ics23@0.6.8':
     resolution: {integrity: sha512-wB6uo+3A50m0sW/EWcU64xpV/8wShZ6bMTa7pF8eYsTrSkQA7oLUIJcs/wb8g4y2Oyq701BaGiO6n/ak5WXO1w==}
 
-  '@connectrpc/connect-web@1.4.0':
-    resolution: {integrity: sha512-13aO4psFbbm7rdOFGV0De2Za64DY/acMspgloDlcOKzLPPs0yZkhp1OOzAQeiAIr7BM/VOHIA3p8mF0inxCYTA==}
+  '@connectrpc/connect-web@1.6.1':
+    resolution: {integrity: sha512-GVfxQOmt3TtgTaKeXLS/EA2IHa3nHxwe2BCHT7X0Q/0hohM+nP5DDnIItGEjGrGdt3LTTqWqE4s70N4h+qIMlQ==}
     peerDependencies:
-      '@bufbuild/protobuf': ^1.4.2
-      '@connectrpc/connect': 1.4.0
+      '@bufbuild/protobuf': ^1.10.0
+      '@connectrpc/connect': 1.6.1
 
-  '@connectrpc/connect@1.4.0':
-    resolution: {integrity: sha512-vZeOkKaAjyV4+RH3+rJZIfDFJAfr+7fyYr6sLDKbYX3uuTVszhFe9/YKf5DNqrDb5cKdKVlYkGn6DTDqMitAnA==}
+  '@connectrpc/connect@1.6.1':
+    resolution: {integrity: sha512-KchMDNtU4CDTdkyf0qG7ugJ6qHTOR/aI7XebYn3OTCNagaDYWiZUVKgRgwH79yeMkpNgvEUaXSK7wKjaBK9b/Q==}
     peerDependencies:
-      '@bufbuild/protobuf': ^1.4.2
+      '@bufbuild/protobuf': ^1.10.0
 
   '@cosmjs/amino@0.32.4':
     resolution: {integrity: sha512-zKYOt6hPy8obIFtLie/xtygCkH9ZROiQ12UHfKsOkWaZfPQUvVbtgmu6R4Kn1tFLI/SRkw7eqhaogmW/3NYu/Q==}
@@ -8502,12 +8502,12 @@ snapshots:
       '@noble/hashes': 1.5.0
       protobufjs: 6.11.4
 
-  '@connectrpc/connect-web@1.4.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.4.0(@bufbuild/protobuf@1.10.0))':
+  '@connectrpc/connect-web@1.6.1(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.6.1(@bufbuild/protobuf@1.10.0))':
     dependencies:
       '@bufbuild/protobuf': 1.10.0
-      '@connectrpc/connect': 1.4.0(@bufbuild/protobuf@1.10.0)
+      '@connectrpc/connect': 1.6.1(@bufbuild/protobuf@1.10.0)
 
-  '@connectrpc/connect@1.4.0(@bufbuild/protobuf@1.10.0)':
+  '@connectrpc/connect@1.6.1(@bufbuild/protobuf@1.10.0)':
     dependencies:
       '@bufbuild/protobuf': 1.10.0
 
@@ -9252,10 +9252,10 @@ snapshots:
       '@penumbra-zone/protobuf': 9.0.0(@bufbuild/protobuf@1.10.0)
       bech32: 2.0.0
 
-  '@penumbra-zone/client@26.0.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.4.0(@bufbuild/protobuf@1.10.0))(@penumbra-zone/protobuf@9.0.0(@bufbuild/protobuf@1.10.0))(@penumbra-zone/transport-dom@7.5.1)':
+  '@penumbra-zone/client@26.0.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.6.1(@bufbuild/protobuf@1.10.0))(@penumbra-zone/protobuf@9.0.0(@bufbuild/protobuf@1.10.0))(@penumbra-zone/transport-dom@7.5.1)':
     dependencies:
       '@bufbuild/protobuf': 1.10.0
-      '@connectrpc/connect': 1.4.0(@bufbuild/protobuf@1.10.0)
+      '@connectrpc/connect': 1.6.1(@bufbuild/protobuf@1.10.0)
       '@penumbra-zone/protobuf': 9.0.0(@bufbuild/protobuf@1.10.0)
       '@penumbra-zone/transport-dom': 7.5.1
 
@@ -9315,10 +9315,10 @@ snapshots:
     dependencies:
       '@bufbuild/protobuf': 1.10.0
 
-  '@penumbra-zone/services@56.0.0(x5cv7ko3dpj5ndqifdtjekdeki)':
+  '@penumbra-zone/services@56.0.0(xdxk3yacyqjn4re2ijx75tncgu)':
     dependencies:
       '@bufbuild/protobuf': 1.10.0
-      '@connectrpc/connect': 1.4.0(@bufbuild/protobuf@1.10.0)
+      '@connectrpc/connect': 1.6.1(@bufbuild/protobuf@1.10.0)
       '@penumbra-zone/bech32m': 15.0.0(@penumbra-zone/protobuf@9.0.0(@bufbuild/protobuf@1.10.0))
       '@penumbra-zone/crypto-web': 39.0.0(@penumbra-zone/types@32.0.0(@bufbuild/protobuf@1.10.0)(@penumbra-zone/bech32m@15.0.0(@penumbra-zone/protobuf@9.0.0(@bufbuild/protobuf@1.10.0)))(@penumbra-zone/getters@25.0.0(@bufbuild/protobuf@1.10.0)(@penumbra-zone/bech32m@15.0.0(@penumbra-zone/protobuf@9.0.0(@bufbuild/protobuf@1.10.0)))(@penumbra-zone/protobuf@9.0.0(@bufbuild/protobuf@1.10.0)))(@penumbra-zone/protobuf@9.0.0(@bufbuild/protobuf@1.10.0)))
       '@penumbra-zone/getters': 25.0.0(@bufbuild/protobuf@1.10.0)(@penumbra-zone/bech32m@15.0.0(@penumbra-zone/protobuf@9.0.0(@bufbuild/protobuf@1.10.0)))(@penumbra-zone/protobuf@9.0.0(@bufbuild/protobuf@1.10.0))
@@ -9339,16 +9339,16 @@ snapshots:
       '@penumbra-zone/wasm': 43.0.0(@bufbuild/protobuf@1.10.0)(@penumbra-zone/bech32m@15.0.0(@penumbra-zone/protobuf@9.0.0(@bufbuild/protobuf@1.10.0)))(@penumbra-zone/protobuf@9.0.0(@bufbuild/protobuf@1.10.0))(@penumbra-zone/types@32.0.0(@bufbuild/protobuf@1.10.0)(@penumbra-zone/bech32m@15.0.0(@penumbra-zone/protobuf@9.0.0(@bufbuild/protobuf@1.10.0)))(@penumbra-zone/getters@25.0.0(@bufbuild/protobuf@1.10.0)(@penumbra-zone/bech32m@15.0.0(@penumbra-zone/protobuf@9.0.0(@bufbuild/protobuf@1.10.0)))(@penumbra-zone/protobuf@9.0.0(@bufbuild/protobuf@1.10.0)))(@penumbra-zone/protobuf@9.0.0(@bufbuild/protobuf@1.10.0)))
       idb: 8.0.0
 
-  '@penumbra-zone/transport-chrome@9.0.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.4.0(@bufbuild/protobuf@1.10.0))(@penumbra-zone/transport-dom@7.5.1)':
+  '@penumbra-zone/transport-chrome@9.0.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.6.1(@bufbuild/protobuf@1.10.0))(@penumbra-zone/transport-dom@7.5.1)':
     dependencies:
       '@bufbuild/protobuf': 1.10.0
-      '@connectrpc/connect': 1.4.0(@bufbuild/protobuf@1.10.0)
+      '@connectrpc/connect': 1.6.1(@bufbuild/protobuf@1.10.0)
       '@penumbra-zone/transport-dom': 7.5.1
 
   '@penumbra-zone/transport-dom@7.5.1':
     dependencies:
       '@bufbuild/protobuf': 1.10.0
-      '@connectrpc/connect': 1.4.0(@bufbuild/protobuf@1.10.0)
+      '@connectrpc/connect': 1.6.1(@bufbuild/protobuf@1.10.0)
 
   '@penumbra-zone/types@32.0.0(@bufbuild/protobuf@1.10.0)(@penumbra-zone/bech32m@15.0.0(@penumbra-zone/protobuf@9.0.0(@bufbuild/protobuf@1.10.0)))(@penumbra-zone/getters@25.0.0(@bufbuild/protobuf@1.10.0)(@penumbra-zone/bech32m@15.0.0(@penumbra-zone/protobuf@9.0.0(@bufbuild/protobuf@1.10.0)))(@penumbra-zone/protobuf@9.0.0(@bufbuild/protobuf@1.10.0)))(@penumbra-zone/protobuf@9.0.0(@bufbuild/protobuf@1.10.0))':
     dependencies:


### PR DESCRIPTION
pins `@bufbuild/protobuf`, `@connectrpc/connect`, `@connectrpc/connect-web` to the specific versioned deps used in the web / dex repos as part of the migration. The former, `^1.x`, caused mismatched a peer deep resolution and was throwing connectrpc errors.

-------------
<img width="1837" alt="Screenshot 2025-03-26 at 4 40 43 AM" src="https://github.com/user-attachments/assets/c77b5ee5-2759-4aab-9dcb-66b5776b2a12" />


<img width="1837" alt="Screenshot 2025-03-26 at 4 05 58 AM" src="https://github.com/user-attachments/assets/23a852a2-b202-4f03-b0f1-57def0feea48" />
