### PR TITLE
fix(ui): #2235: approval dialog styles

### DIFF
--- a/.changeset/happy-needles-warn.md
+++ b/.changeset/happy-needles-warn.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': patch
+---
+
+Fix styles of action views in approval dialog

--- a/packages/ui/components/ui/tx/actions-views/liquidity-tournament-vote.tsx
+++ b/packages/ui/components/ui/tx/actions-views/liquidity-tournament-vote.tsx
@@ -29,7 +29,7 @@ export const LiquidityTournamentVoteComponent = ({
               <ValueViewComponent view={value.liquidityTournamentVote.value.note?.value} />
             </ValueWithAddress>
             {value.liquidityTournamentVote.value.vote && (
-              <ActionDetails.Row label='Liquidity Tournament Vote'>
+              <ActionDetails.Row label='Voting power'>
                 <ValueViewComponent view={globalValueView} />
               </ActionDetails.Row>
             )}

--- a/packages/ui/components/ui/tx/actions-views/output.tsx
+++ b/packages/ui/components/ui/tx/actions-views/output.tsx
@@ -14,7 +14,7 @@ export const OutputViewComponent = ({ value }: { value: OutputView }) => {
       <ViewBox
         label='Output'
         visibleContent={
-          <div className='flex items-center justify-between gap-3'>
+          <div className='flex items-center justify-between gap-x-3 gap-y-0 flex-wrap'>
             <ValueViewComponent view={note.value} />
             <ValueWithAddress addressView={address} label='to'>
               <></>

--- a/packages/ui/components/ui/tx/actions-views/spend.tsx
+++ b/packages/ui/components/ui/tx/actions-views/spend.tsx
@@ -14,7 +14,7 @@ export const SpendViewComponent = ({ value }: { value: SpendView }) => {
       <ViewBox
         label='Spend'
         visibleContent={
-          <div className='flex items-center justify-between gap-3'>
+          <div className='flex items-center justify-between gap-x-3 gap-y-0 flex-wrap'>
             <ValueViewComponent view={note.value} />
             <ValueWithAddress addressView={address} label='from'>
               <></>

--- a/packages/ui/components/ui/tx/actions-views/value-with-address.tsx
+++ b/packages/ui/components/ui/tx/actions-views/value-with-address.tsx
@@ -21,9 +21,7 @@ export const ValueWithAddress = ({
     {addressView && (
       <div className='flex items-center gap-2 overflow-hidden'>
         <span className='whitespace-nowrap font-mono text-sm italic text-foreground'>{label}</span>
-        <div className='max-w-[150px] truncate'>
-          <AddressViewComponent view={addressView} />
-        </div>
+        <AddressViewComponent view={addressView} />
       </div>
     )}
   </div>

--- a/packages/ui/components/ui/value/value.tsx
+++ b/packages/ui/components/ui/value/value.tsx
@@ -38,7 +38,10 @@ export const ValueComponent = ({
         </span>
       )}
       {showDenom && (
-        <span className='max-w-[80px] truncate font-mono text-xs text-muted-foreground'>
+        <span
+          className='max-w-[80px] truncate font-mono text-xs text-muted-foreground'
+          title={symbol}
+        >
           {symbol}
         </span>
       )}


### PR DESCRIPTION
Closes https://github.com/penumbra-zone/web/issues/2235

Small changes for better display of action views in the old designs of the action views.

After the changes:

<img width="378" alt="image" src="https://github.com/user-attachments/assets/501bbf81-61d8-403b-bf45-cfb4c94d1b81" />

<img width="387" alt="image" src="https://github.com/user-attachments/assets/5be25eb2-62be-4d77-8cfd-379f45dadcbe" />
