### PR TITLE
process epoch consistently

### DIFF
--- a/packages/query/src/block-processor.ts
+++ b/packages/query/src/block-processor.ts
@@ -227,7 +227,9 @@ export class BlockProcessor implements BlockProcessorInterface {
         currentEpoch++;
         await this.indexedDb.addEpoch({ index: currentEpoch, startHeight: currentHeight });
 
-        await this.indexedDb.updateValidatorInfo(this.querier.stake.allValidatorInfos());
+        if (compactBlock.height === 0n || latestKnownBlockHeight === compactBlock.height) {
+          await this.indexedDb.updateValidatorInfo(this.querier.stake.allValidatorInfos());
+        }
       }
     }
   }


### PR DESCRIPTION
depends on 

- [ ] https://github.com/penumbra-zone/web/pull/2242
- [ ] https://github.com/penumbra-zone/web/pull/2258

the intent here was to move epoch increment before flush, because `saveScanResult` called here

https://github.com/prax-wallet/prax/blob/a61f49bcbc0929d8d491357a5b1ebed38d677af9/packages/query/src/block-processor.ts#L282-L290

calls `addNewSwaps` https://github.com/penumbra-zone/web/blob/51eea2bcd83cfc16c8afe5afe9a69b637cfe523f/packages/storage/src/indexed-db/index.ts#L222-L232

calls `getEpochByHeight` https://github.com/penumbra-zone/web/blob/51eea2bcd83cfc16c8afe5afe9a69b637cfe523f/packages/storage/src/indexed-db/index.ts#L1000-L1010

which breaks if `getEpochByHeight` is fixed, as in  https://github.com/penumbra-zone/web/pull/2242

so now, epoch update is handled more consistently.

the validator state update could be reverted partially or improved, but validator state update is also sensitive to changes in epoch change. 