### PR TITLE
add nix flake for dev env

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -1,0 +1,2 @@
+export CHROMIUM_PROFILE=chromium-profile
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ dist-ssr
 .env.development.local
 .env.test.local
 .env.production.local
+.envrc
+.direnv/
 
 # turbo
 .turbo
@@ -64,3 +66,6 @@ packages/*/package
 apps/extension/chromium-profile
 
 scripts/private
+
+# nix
+/result

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ each respective package.
 - [Install pnpm](https://pnpm.io/installation) (probably via corepack)
 - Install Google Chrome (Chromium works but we have encountered behavioral differences)
 
+Or you can use [nix](https://nixos.org/download/) to create a devshell via `nix develop`.
+
 ### Building
 
 Once you have all these tools, you can

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1739206421,
+        "narHash": "sha256-PwQASeL2cGVmrtQYlrBur0U20Xy07uSWVnFup2PHnDs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "44534bc021b85c8d78e465021e21f33b856e2540",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,26 @@
+{
+  description = "Dev shell for Prax wallet web extension";
+  # inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let pkgs = nixpkgs.legacyPackages.${system}; in
+      {
+        devShells.default = pkgs.mkShell {
+          name = "devShell";
+          nativeBuildInputs = [ pkgs.bashInteractive ];
+          buildInputs = with pkgs; [
+            fd
+            file
+            jq
+            just
+            pnpm
+            nodejs_22
+            postgresql
+            wasm-pack
+          ];
+        };
+      });
+}

--- a/justfile
+++ b/justfile
@@ -1,0 +1,15 @@
+# run local dev env
+dev: install
+  pnpm dev
+
+# install all node dependencies, via pnpm
+install:
+  pnpm install
+
+# build all sources
+build:
+  pnpm turbo build
+
+# run tests
+test:
+  pnpm turbo test


### PR DESCRIPTION
Creates a nix flake to manage dev dependencies, same as present in the other related dependency repos, such as web [0]. My goal in submitting this PR is simply to make life easier for developers when switching between repos, provided they've some familiarity with nix.

The nix flake provides a devshell, but does not declare any build targets: all packaging and distribution logic for the extension remains unchanged.

[0] https://github.com/penumbra-zone/web