### PR TITLE
registry: default rpc selection

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -18,7 +18,7 @@
     "@bufbuild/protobuf": "^1.10.0",
     "@connectrpc/connect": "^1.6.1",
     "@connectrpc/connect-web": "^1.6.1",
-    "@penumbra-labs/registry": "^12.5.1",
+    "@penumbra-labs/registry": "^12.7.0",
     "@penumbra-zone/bech32m": "16.0.0",
     "@penumbra-zone/client": "27.0.0",
     "@penumbra-zone/crypto-web": "42.0.0",

--- a/apps/extension/src/hooks/latest-block-height.ts
+++ b/apps/extension/src/hooks/latest-block-height.ts
@@ -18,7 +18,7 @@ export const fetchBlockHeightWithFallback = async (
     throw new Error('All RPC endpoints failed to fetch the block height.');
   }
 
-  // Define a canconcial default RPC
+  // Define a canonical default RPC
   const defaultRpc = 'https://penumbra-1.radiantcommons.com';
 
   let selectedGrpc: string | undefined = endpoints.find(endpoint => endpoint === defaultRpc);

--- a/apps/extension/src/hooks/latest-block-height.ts
+++ b/apps/extension/src/hooks/latest-block-height.ts
@@ -21,7 +21,7 @@ export const fetchBlockHeightWithFallback = async (
   // Define a canconcial default RPC
   const defaultRpc = 'https://penumbra-1.radiantcommons.com';
 
-  let selectedGrpc = endpoints.find(endpoint => endpoint === defaultRpc);
+  let selectedGrpc: string | undefined = endpoints.find(endpoint => endpoint === defaultRpc);
 
   // If default RPC is not found, randomly sample an RPC endpoint from the chain registry
   if (!selectedGrpc) {

--- a/apps/extension/src/hooks/latest-block-height.ts
+++ b/apps/extension/src/hooks/latest-block-height.ts
@@ -7,10 +7,9 @@ import { useStore } from '../state';
 import { networkSelector } from '../state/network';
 
 // Utility function to fetch the block height by randomly querying one of the RPC endpoints
-// from the chain registry, using a recursive callback to try another endpoint if the current
-// one fails. Additionally, this implements a timeout mechanism at the request level to avoid
-// hanging from stalled requests.
-
+// from the chain registry (if default is unavailable), using a recursive callback to try
+// another endpoint for liveness if the current one fails. Additionally, this implements a
+// timeout mechanism at the request level to avoid hanging from stalled requests.
 export const fetchBlockHeightWithFallback = async (
   endpoints: string[],
   transport?: Transport, // Deps injection mostly for unit tests
@@ -19,18 +18,25 @@ export const fetchBlockHeightWithFallback = async (
     throw new Error('All RPC endpoints failed to fetch the block height.');
   }
 
-  // Randomly select an RPC endpoint from the chain registry
-  const randomGrpcEndpoint = sample(endpoints);
-  if (!randomGrpcEndpoint) {
+  // Define a canconcial default RPC
+  const defaultRpc = 'Radiant Commons';
+
+  let selectedGrpc = endpoints.find(endpoint => endpoint === defaultRpc);
+
+  // If default RPC is not found, randomly sample an RPC endpoint from the chain registry
+  if (!selectedGrpc) {
+    selectedGrpc = sample(endpoints);
+  }
+  if (!selectedGrpc) {
     throw new Error('No RPC endpoints found.');
   }
 
   try {
-    const blockHeight = await fetchBlockHeightWithTimeout(randomGrpcEndpoint, transport);
-    return { blockHeight, rpc: randomGrpcEndpoint };
+    const blockHeight = await fetchBlockHeightWithTimeout(selectedGrpc, transport);
+    return { blockHeight, rpc: selectedGrpc };
   } catch (e) {
     // Remove the current endpoint from the list and retry with remaining endpoints
-    const remainingEndpoints = endpoints.filter(endpoint => endpoint !== randomGrpcEndpoint);
+    const remainingEndpoints = endpoints.filter(endpoint => endpoint !== selectedGrpc);
     return fetchBlockHeightWithFallback(remainingEndpoints, transport);
   }
 };

--- a/apps/extension/src/hooks/latest-block-height.ts
+++ b/apps/extension/src/hooks/latest-block-height.ts
@@ -19,7 +19,7 @@ export const fetchBlockHeightWithFallback = async (
   }
 
   // Define a canconcial default RPC
-  const defaultRpc = 'Radiant Commons';
+  const defaultRpc = 'https://penumbra-1.radiantcommons.com';
 
   let selectedGrpc = endpoints.find(endpoint => endpoint === defaultRpc);
 

--- a/apps/extension/src/routes/page/onboarding/password/utils.ts
+++ b/apps/extension/src/routes/page/onboarding/password/utils.ts
@@ -36,13 +36,13 @@ export const setOnboardingValuesInStorage = async (seedPhraseOrigin: SEED_PHRASE
   const { rpcs, frontends } = await chainRegistryClient.remote.globals();
 
   // Define a canconcial default frontend
-  const defaultFront = 'Radiant Commons';
+  const defaultFrontend = 'Radiant Commons';
 
   let selectedFrontend: EntityMetadata | undefined = frontends.find(
-    frontend => frontend.name === defaultFront,
+    frontend => frontend.name === defaultFrontend,
   );
 
-  // If default frontend is not found, randomly select a frontend
+  // If default frontend is not found, randomly sample a frontend
   if (!selectedFrontend) {
     selectedFrontend = sample(frontends);
   }

--- a/apps/extension/src/routes/page/onboarding/password/utils.ts
+++ b/apps/extension/src/routes/page/onboarding/password/utils.ts
@@ -35,7 +35,7 @@ export const setOnboardingValuesInStorage = async (seedPhraseOrigin: SEED_PHRASE
   const chainRegistryClient = new ChainRegistryClient();
   const { rpcs, frontends } = await chainRegistryClient.remote.globals();
 
-  // Define a canconcial default frontend
+  // Define a canonical default frontend
   const defaultFrontend = 'Radiant Commons';
 
   let selectedFrontend: EntityMetadata | undefined = frontends.find(

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -17,7 +17,7 @@
   },
   "peerDependencies": {
     "@bufbuild/protobuf": "^1.10.0",
-    "@penumbra-labs/registry": "^12.5.1",
+    "@penumbra-labs/registry": "^12.7.0",
     "@penumbra-zone/bech32m": "16.0.0",
     "@penumbra-zone/crypto-web": "42.0.0",
     "@penumbra-zone/getters": "26.0.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
-    "@penumbra-labs/registry": "^12.5.1",
+    "@penumbra-labs/registry": "^12.7.0",
     "@penumbra-zone/bech32m": "16.0.0",
     "@penumbra-zone/getters": "26.0.0",
     "@penumbra-zone/perspective": "55.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,8 +87,8 @@ importers:
         specifier: ^1.6.1
         version: 1.6.1(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.6.1(@bufbuild/protobuf@1.10.0))
       '@penumbra-labs/registry':
-        specifier: ^12.5.1
-        version: 12.5.1
+        specifier: ^12.7.0
+        version: 12.7.0
       '@penumbra-zone/bech32m':
         specifier: 16.0.0
         version: 16.0.0(@penumbra-zone/protobuf@10.0.0(@bufbuild/protobuf@1.10.0))
@@ -115,10 +115,10 @@ importers:
         version: link:../../packages/query
       '@penumbra-zone/services':
         specifier: 61.0.0
-        version: 61.0.0(iubqrhxpmhk7tvludzgtvzz2e4)
+        version: 61.0.0(c4h52vepyqn5ndh466xzzqn6xq)
       '@penumbra-zone/storage':
         specifier: 55.0.0
-        version: 55.0.0(jyhgo6ofvzw5uplre57rfgp67m)
+        version: 55.0.0(lrhfolnakiylk7wyzb3uj25m2u)
       '@penumbra-zone/transport-chrome':
         specifier: 9.0.0
         version: 9.0.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.6.1(@bufbuild/protobuf@1.10.0))(@penumbra-zone/transport-dom@7.5.1)
@@ -256,8 +256,8 @@ importers:
         specifier: ^1.10.0
         version: 1.10.0
       '@penumbra-labs/registry':
-        specifier: ^12.5.1
-        version: 12.5.1
+        specifier: ^12.7.0
+        version: 12.7.0
       '@penumbra-zone/bech32m':
         specifier: 16.0.0
         version: 16.0.0(@penumbra-zone/protobuf@10.0.0(@bufbuild/protobuf@1.10.0))
@@ -281,10 +281,10 @@ importers:
         version: link:../query
       '@penumbra-zone/services':
         specifier: 61.0.0
-        version: 61.0.0(iubqrhxpmhk7tvludzgtvzz2e4)
+        version: 61.0.0(c4h52vepyqn5ndh466xzzqn6xq)
       '@penumbra-zone/storage':
         specifier: 55.0.0
-        version: 55.0.0(jyhgo6ofvzw5uplre57rfgp67m)
+        version: 55.0.0(lrhfolnakiylk7wyzb3uj25m2u)
       '@penumbra-zone/transport-chrome':
         specifier: 9.0.0
         version: 9.0.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.6.1(@bufbuild/protobuf@1.10.0))(@penumbra-zone/transport-dom@7.5.1)
@@ -375,8 +375,8 @@ importers:
         specifier: ^11.14.0
         version: 11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1)
       '@penumbra-labs/registry':
-        specifier: ^12.5.1
-        version: 12.5.1
+        specifier: ^12.7.0
+        version: 12.7.0
       '@penumbra-zone/bech32m':
         specifier: 16.0.0
         version: 16.0.0(@penumbra-zone/protobuf@10.0.0(@bufbuild/protobuf@1.10.0))
@@ -1599,8 +1599,8 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
-  '@penumbra-labs/registry@12.5.1':
-    resolution: {integrity: sha512-2JPKJ2iGUfS0z5yQE6VgFifZYwpnvv3qGMojji8QL9/oqCHxSST9Yy1UyWgG/LYO1EV4GFUl2QMvXH84Z8XxXA==}
+  '@penumbra-labs/registry@12.7.0':
+    resolution: {integrity: sha512-KKnOd2wFk061WlanF8ONrQ7+wiRLDZemH4GeQBng86kiFNjwMx+z9TTs4fStd4FmCdrxdSBuio5Mdf9+bIK0ng==}
 
   '@penumbra-zone/bech32m@16.0.0':
     resolution: {integrity: sha512-/v1Chln5Uafo9OcZfWynD3xOFb1AenMIsc4DeOUdB5lkxzE6NE43ev7iCTH2MADAzvkcM1Rr5NNE9z2hWtucTw==}
@@ -9238,7 +9238,7 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
-  '@penumbra-labs/registry@12.5.1': {}
+  '@penumbra-labs/registry@12.7.0': {}
 
   '@penumbra-zone/bech32m@16.0.0(@penumbra-zone/protobuf@10.0.0(@bufbuild/protobuf@1.10.0))':
     dependencies:
@@ -9308,7 +9308,7 @@ snapshots:
     dependencies:
       '@bufbuild/protobuf': 1.10.0
 
-  '@penumbra-zone/services@61.0.0(iubqrhxpmhk7tvludzgtvzz2e4)':
+  '@penumbra-zone/services@61.0.0(c4h52vepyqn5ndh466xzzqn6xq)':
     dependencies:
       '@bufbuild/protobuf': 1.10.0
       '@connectrpc/connect': 1.6.1(@bufbuild/protobuf@1.10.0)
@@ -9316,15 +9316,15 @@ snapshots:
       '@penumbra-zone/crypto-web': 42.0.0(@penumbra-zone/types@33.0.0(@bufbuild/protobuf@1.10.0)(@penumbra-zone/bech32m@16.0.0(@penumbra-zone/protobuf@10.0.0(@bufbuild/protobuf@1.10.0)))(@penumbra-zone/getters@26.0.0(@bufbuild/protobuf@1.10.0)(@penumbra-zone/bech32m@16.0.0(@penumbra-zone/protobuf@10.0.0(@bufbuild/protobuf@1.10.0)))(@penumbra-zone/protobuf@10.0.0(@bufbuild/protobuf@1.10.0)))(@penumbra-zone/protobuf@10.0.0(@bufbuild/protobuf@1.10.0)))
       '@penumbra-zone/getters': 26.0.0(@bufbuild/protobuf@1.10.0)(@penumbra-zone/bech32m@16.0.0(@penumbra-zone/protobuf@10.0.0(@bufbuild/protobuf@1.10.0)))(@penumbra-zone/protobuf@10.0.0(@bufbuild/protobuf@1.10.0))
       '@penumbra-zone/protobuf': 10.0.0(@bufbuild/protobuf@1.10.0)
-      '@penumbra-zone/storage': 55.0.0(jyhgo6ofvzw5uplre57rfgp67m)
+      '@penumbra-zone/storage': 55.0.0(lrhfolnakiylk7wyzb3uj25m2u)
       '@penumbra-zone/transport-dom': 7.5.1
       '@penumbra-zone/types': 33.0.0(@bufbuild/protobuf@1.10.0)(@penumbra-zone/bech32m@16.0.0(@penumbra-zone/protobuf@10.0.0(@bufbuild/protobuf@1.10.0)))(@penumbra-zone/getters@26.0.0(@bufbuild/protobuf@1.10.0)(@penumbra-zone/bech32m@16.0.0(@penumbra-zone/protobuf@10.0.0(@bufbuild/protobuf@1.10.0)))(@penumbra-zone/protobuf@10.0.0(@bufbuild/protobuf@1.10.0)))(@penumbra-zone/protobuf@10.0.0(@bufbuild/protobuf@1.10.0))
       '@penumbra-zone/wasm': 46.0.0(@bufbuild/protobuf@1.10.0)(@penumbra-zone/bech32m@16.0.0(@penumbra-zone/protobuf@10.0.0(@bufbuild/protobuf@1.10.0)))(@penumbra-zone/protobuf@10.0.0(@bufbuild/protobuf@1.10.0))(@penumbra-zone/types@33.0.0(@bufbuild/protobuf@1.10.0)(@penumbra-zone/bech32m@16.0.0(@penumbra-zone/protobuf@10.0.0(@bufbuild/protobuf@1.10.0)))(@penumbra-zone/getters@26.0.0(@bufbuild/protobuf@1.10.0)(@penumbra-zone/bech32m@16.0.0(@penumbra-zone/protobuf@10.0.0(@bufbuild/protobuf@1.10.0)))(@penumbra-zone/protobuf@10.0.0(@bufbuild/protobuf@1.10.0)))(@penumbra-zone/protobuf@10.0.0(@bufbuild/protobuf@1.10.0)))
 
-  '@penumbra-zone/storage@55.0.0(jyhgo6ofvzw5uplre57rfgp67m)':
+  '@penumbra-zone/storage@55.0.0(lrhfolnakiylk7wyzb3uj25m2u)':
     dependencies:
       '@bufbuild/protobuf': 1.10.0
-      '@penumbra-labs/registry': 12.5.1
+      '@penumbra-labs/registry': 12.7.0
       '@penumbra-zone/bech32m': 16.0.0(@penumbra-zone/protobuf@10.0.0(@bufbuild/protobuf@1.10.0))
       '@penumbra-zone/getters': 26.0.0(@bufbuild/protobuf@1.10.0)(@penumbra-zone/bech32m@16.0.0(@penumbra-zone/protobuf@10.0.0(@bufbuild/protobuf@1.10.0)))(@penumbra-zone/protobuf@10.0.0(@bufbuild/protobuf@1.10.0))
       '@penumbra-zone/protobuf': 10.0.0(@bufbuild/protobuf@1.10.0)


### PR DESCRIPTION
defaults to the RC-hosted high-performance and reliable RPC `https://penumbra-1.radiantcommons.com/` during onboarding.

requires bumping the npm registry version to `12.7.0` after https://github.com/prax-wallet/registry/pull/142 lands to pass CI.

---------------

<img width="351" alt="Screenshot 2025-04-30 at 6 36 33 AM" src="https://github.com/user-attachments/assets/0b748205-8739-40c1-b8c4-8588c6305453" />
