### PR TITLE
feat(quick-sync): TCT frontier support

### DIFF
--- a/packages/query/src/block-processor.ts
+++ b/packages/query/src/block-processor.ts
@@ -171,6 +171,10 @@ export class BlockProcessor implements BlockProcessorInterface {
     // prepares for syncing and checks for a bundled genesis block,
     // which can save time by avoiding an initial network request.
     if (currentHeight === PRE_GENESIS_SYNC_HEIGHT) {
+
+      // STUB SCT CALL
+      // let frontier = await this.querier.sct.sctFrontier(new SctFrontierRequest({ withProof: true }))
+
       // create first epoch
       await this.indexedDb.addEpoch(0n);
 

--- a/packages/query/src/queriers/sct.ts
+++ b/packages/query/src/queriers/sct.ts
@@ -5,6 +5,8 @@ import { SctQuerierInterface } from '@penumbra-zone/types/querier';
 import {
   TimestampByHeightRequest,
   TimestampByHeightResponse,
+  SctFrontierRequest,
+  SctFrontierResponse,
 } from '@penumbra-zone/protobuf/penumbra/core/component/sct/v1/sct_pb';
 
 export class SctQuerier implements SctQuerierInterface {
@@ -13,7 +15,12 @@ export class SctQuerier implements SctQuerierInterface {
   constructor({ grpcEndpoint }: { grpcEndpoint: string }) {
     this.client = createClient(grpcEndpoint, SctService);
   }
+
   timestampByHeight(req: TimestampByHeightRequest): Promise<TimestampByHeightResponse> {
     return this.client.timestampByHeight(req);
+  }
+
+  sctFrontier(req: SctFrontierRequest): Promise<SctFrontierResponse> {
+    return this.client.sctFrontier(req);
   }
 }


### PR DESCRIPTION
pairs with https://github.com/penumbra-zone/web/pull/2303

currently getting connectrpc errors when trying to query the `sctFrontier` rpc method because full node on testnet hasn't picked up the latest SCT service. 