### PR TITLE
feat: perform visible transaction validation

### DIFF
--- a/apps/extension/src/ctx/authorization.ts
+++ b/apps/extension/src/ctx/authorization.ts
@@ -28,7 +28,7 @@ export const getAuthorization = async (plan: TransactionPlan): Promise<Authoriza
     .then(response => response?.choice === UserChoice.Approved)
     .catch(error => {
       console.error(error);
-      throw new ConnectError('Authorization failed', Code.Internal);
+      throw new ConnectError('Approval failed', Code.Internal);
     });
 
   const [authorizationData, approval] = await Promise.all([authorize, choose]);

--- a/apps/extension/src/ctx/authorization.ts
+++ b/apps/extension/src/ctx/authorization.ts
@@ -15,40 +15,39 @@ import { throwIfNeedsLogin } from '../needs-login';
 import { popup } from '../popup';
 
 export const getAuthorization = async (plan: TransactionPlan): Promise<AuthorizationData> => {
-  await throwIfNeedsLogin();
-
-  const authorization = openWallet().then(custody => custody.authorizePlan(plan));
-
-  const approval = popup(PopupType.TxApproval, {
-    authorizeRequest: new AuthorizeRequest({ plan }).toJson() as Jsonified<AuthorizeRequest>,
-  });
-
-  const [authorizationData] = await Promise.all([
-    authorization.catch(error => {
+  const authorize = openWallet()
+    .then(custody => custody.authorizePlan(plan))
+    .catch(error => {
       console.error(error);
       throw new ConnectError('Authorization failed', Code.Internal);
-    }),
-    approval.then(
-      response => {
-        if (response?.choice !== UserChoice.Approved) {
-          throw new ConnectError('Authorization denied', Code.PermissionDenied);
-        }
-      },
-      error => {
-        console.error(error);
-        throw new ConnectError('Authorization failed', Code.Internal);
-      },
-    ),
-  ]);
+    });
+
+  const choose = popup(PopupType.TxApproval, {
+    authorizeRequest: new AuthorizeRequest({ plan }).toJson() as Jsonified<AuthorizeRequest>,
+  })
+    .then(response => response?.choice === UserChoice.Approved)
+    .catch(error => {
+      console.error(error);
+      throw new ConnectError('Authorization failed', Code.Internal);
+    });
+
+  const [authorizationData, approval] = await Promise.all([authorize, choose]);
+
+  if (!approval) {
+    throw new ConnectError('Authorization denied', Code.PermissionDenied);
+  }
 
   return authorizationData;
 };
 
 const openWallet = async () => {
-  const [passKey, wallet] = await Promise.all([
-    sessionExtStorage.get('passwordKey').then(passKeyJson => Key.fromJson(passKeyJson!)),
-    localExtStorage.get('wallets').then(wallets => Wallet.fromJson(wallets[0]!)),
-  ]);
+  await throwIfNeedsLogin();
 
-  return wallet.custody(passKey);
+  const passKey = sessionExtStorage
+    .get('passwordKey')
+    .then(passKeyJson => Key.fromJson(passKeyJson!));
+
+  const wallet = localExtStorage.get('wallets').then(wallets => Wallet.fromJson(wallets[0]!));
+
+  return (await wallet).custody(await passKey);
 };

--- a/apps/extension/src/routes/popup/approval/approve-deny.tsx
+++ b/apps/extension/src/routes/popup/approval/approve-deny.tsx
@@ -6,7 +6,7 @@ export const ApproveDeny = ({
   deny,
   ignore,
 }: {
-  approve: () => void;
+  approve?: () => void;
   deny: () => void;
   ignore?: () => void;
   wait?: number;
@@ -27,7 +27,7 @@ export const ApproveDeny = ({
         className='w-1/2 py-3.5 text-base'
         size='lg'
         onClick={approve}
-        disabled={count > 0}
+        disabled={!approve || count > 0}
       >
         Approve
       </Button>

--- a/apps/extension/src/routes/popup/approval/transaction/use-transaction-view-switcher.ts
+++ b/apps/extension/src/routes/popup/approval/transaction/use-transaction-view-switcher.ts
@@ -20,9 +20,9 @@ export const useTransactionViewSwitcher = (): {
     }
 
     return {
-      asSender: TransactionView.fromJsonString(asSender),
-      asReceiver: TransactionView.fromJsonString(asReceiver),
-      asPublic: TransactionView.fromJsonString(asPublic),
+      asSender: new TransactionView(asSender),
+      asReceiver: new TransactionView(asReceiver),
+      asPublic: new TransactionView(asPublic),
     };
   }, [asSender, asReceiver, asPublic]);
 

--- a/apps/extension/src/state/origin-approval.ts
+++ b/apps/extension/src/state/origin-approval.ts
@@ -28,7 +28,9 @@ export const createOriginApprovalSlice = (): SliceCreator<OriginApprovalSlice> =
     });
   },
 
-  acceptRequest: ({ origin: requestOrigin, favIconUrl, title, lastRequest }) => {
+  acceptRequest: req => {
+    const { origin: requestOrigin, favIconUrl, title, lastRequest } = req;
+
     const existing = get().originApproval;
     if (existing.responder) {
       throw new Error('Another request is still pending');

--- a/apps/extension/src/state/tx-validation/assert-valid-plan.test.ts
+++ b/apps/extension/src/state/tx-validation/assert-valid-plan.test.ts
@@ -1,0 +1,248 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any -- test file */
+import { ActionPlan } from '@penumbra-zone/protobuf/penumbra/core/transaction/v1/transaction_pb';
+import { generateSpendKey, getAddressByIndex, getFullViewingKey } from '@penumbra-zone/wasm/keys';
+import { describe, expect, it } from 'vitest';
+import { assertValidActionPlans } from './assert-valid-plan.js';
+
+const currentUserSeedPhrase =
+  'benefit cherry cannon tooth exhibit law avocado spare tooth that amount pumpkin scene foil tape mobile shine apology add crouch situate sun business explain';
+const currentUserFullViewingKey = getFullViewingKey(generateSpendKey(currentUserSeedPhrase));
+const currentUserAddress = getAddressByIndex(currentUserFullViewingKey, 1);
+
+const otherUserSeedPhrase =
+  'cancel tilt shallow way roast utility profit satoshi mushroom seek shift helmet';
+const otherUserAddress = getAddressByIndex(
+  getFullViewingKey(generateSpendKey(otherUserSeedPhrase)),
+  1,
+);
+
+describe('individual plans', () => {
+  it('rejects an empty action plan', () => {
+    const emptyActionPlan = new ActionPlan({});
+    expect(() => assertValidActionPlans([emptyActionPlan], currentUserFullViewingKey)).toThrow(
+      'Missing action plan',
+    );
+  });
+
+  it('rejects an action missing a value', () => {
+    const planMissingValue = new ActionPlan({});
+    planMissingValue.action.case = 'spend';
+    expect(() => assertValidActionPlans([planMissingValue], currentUserFullViewingKey)).toThrow(
+      'Missing action plan',
+    );
+  });
+
+  it('rejects an action missing a case', () => {
+    const planMissingCase = new ActionPlan({});
+    planMissingCase.action.value = {} as any;
+    planMissingCase.action.case = undefined;
+
+    expect(() => assertValidActionPlans([planMissingCase], currentUserFullViewingKey)).toThrow(
+      'Unknown action plan',
+    );
+  });
+
+  it('rejects an action with some unknown case', () => {
+    const planUnknownCase = new ActionPlan({});
+    planUnknownCase.action.value = {} as any;
+    planUnknownCase.action.case = 'notValid' as ActionPlan['action']['case'];
+    expect(() => assertValidActionPlans([planUnknownCase], currentUserFullViewingKey)).toThrow(
+      'Unknown action plan',
+    );
+  });
+
+  describe('swap actions', () => {
+    it('does not reject when the swap claim address is controlled', () => {
+      const swapWithCurrentUserAddress = new ActionPlan({
+        action: {
+          case: 'swap',
+          value: {
+            swapPlaintext: { claimAddress: currentUserAddress },
+          },
+        },
+      });
+
+      expect(() =>
+        assertValidActionPlans([swapWithCurrentUserAddress], currentUserFullViewingKey),
+      ).not.toThrow();
+    });
+
+    it('rejects when the swap claim address is not controlled', () => {
+      const swapWithOtherUserAddress = new ActionPlan({
+        action: {
+          case: 'swap',
+          value: {
+            swapPlaintext: { claimAddress: otherUserAddress },
+          },
+        },
+      });
+      expect(() =>
+        assertValidActionPlans([swapWithOtherUserAddress], currentUserFullViewingKey),
+      ).toThrow('uncontrolled claim address');
+    });
+
+    it('rejects when the swap claim address is undefined', () => {
+      const swapWithUndefinedAddress = new ActionPlan({
+        action: {
+          case: 'swap',
+          value: {
+            swapPlaintext: {},
+          },
+        },
+      });
+      expect(() =>
+        assertValidActionPlans([swapWithUndefinedAddress], currentUserFullViewingKey),
+      ).toThrow('missing claim address');
+    });
+
+    it('rejects when the swap claim address is all zeroes', () => {
+      const swapWithWrongLengthClaimAddress = new ActionPlan({
+        action: {
+          case: 'swap',
+          value: {
+            swapPlaintext: {
+              claimAddress: { inner: new Uint8Array(80).fill(0) },
+            },
+          },
+        },
+      });
+
+      expect(() =>
+        assertValidActionPlans([swapWithWrongLengthClaimAddress], currentUserFullViewingKey),
+      ).toThrow('missing claim address');
+    });
+  });
+
+  describe('swapClaim actions', () => {
+    it('rejects swapClaim actions which do not require authorization', () => {
+      const swapClaimAction = new ActionPlan({
+        action: {
+          case: 'swapClaim',
+          value: {},
+        },
+      });
+
+      expect(() => assertValidActionPlans([swapClaimAction], currentUserFullViewingKey)).toThrow(
+        'does not require authorization',
+      );
+    });
+  });
+
+  describe('output actions', () => {
+    it.each([undefined, 0, 1, 80, 81])(
+      `rejects when the output destination address is %s zeroes`,
+      innerLength => {
+        const destAddress =
+          innerLength == null ? undefined : { inner: new Uint8Array(innerLength) };
+        expect(() =>
+          assertValidActionPlans(
+            [
+              new ActionPlan({
+                action: {
+                  case: 'output',
+                  value: { destAddress },
+                },
+              }),
+            ],
+            currentUserFullViewingKey,
+          ),
+        ).toThrow('missing destination address');
+      },
+    );
+
+    it.each([
+      { inner: currentUserAddress.inner.slice(1) },
+      { inner: Uint8Array.from([...currentUserAddress.inner, 81]) },
+    ])('rejects when the output destination address is invalid', destAddress => {
+      expect(() =>
+        assertValidActionPlans(
+          [
+            new ActionPlan({
+              action: {
+                case: 'output',
+                value: { destAddress },
+              },
+            }),
+          ],
+          currentUserFullViewingKey,
+        ),
+      ).toThrow('invalid destination address');
+    });
+
+    it('does not reject when the output destination address is nonzero', () => {
+      const outputWithValidDestination = new ActionPlan({
+        action: {
+          case: 'output',
+          value: {
+            destAddress: { inner: new Uint8Array(80).fill(3) },
+          },
+        },
+      });
+
+      expect(() =>
+        assertValidActionPlans([outputWithValidDestination], currentUserFullViewingKey),
+      ).not.toThrow();
+    });
+  });
+});
+
+describe('lists of plans', () => {
+  it('rejects when no actions are provided', () => {
+    expect(() => assertValidActionPlans([], currentUserFullViewingKey)).toThrow(
+      'No actions planned',
+    );
+    expect(() => assertValidActionPlans(undefined, currentUserFullViewingKey)).toThrow(
+      'No actions planned',
+    );
+  });
+
+  it('validates all actions', () => {
+    expect(() =>
+      assertValidActionPlans(
+        [
+          new ActionPlan({
+            action: {
+              case: 'spend',
+              value: {},
+            },
+          }),
+          new ActionPlan({
+            action: {
+              case: 'delegate',
+              value: {},
+            },
+          }),
+        ],
+        currentUserFullViewingKey,
+      ),
+    ).not.toThrow();
+
+    expect(() =>
+      assertValidActionPlans(
+        [
+          new ActionPlan({
+            action: {
+              case: 'spend',
+              value: {},
+            },
+          }),
+          new ActionPlan({
+            action: {
+              case: 'output',
+              value: { destAddress: otherUserAddress },
+            },
+          }),
+          new ActionPlan({
+            action: {
+              case: 'swap',
+              value: {
+                swapPlaintext: { claimAddress: otherUserAddress },
+              },
+            },
+          }),
+        ],
+        currentUserFullViewingKey,
+      ),
+    ).toThrow('uncontrolled claim address');
+  });
+});

--- a/apps/extension/src/state/tx-validation/assert-valid-plan.test.ts
+++ b/apps/extension/src/state/tx-validation/assert-valid-plan.test.ts
@@ -34,7 +34,7 @@ describe('individual plans', () => {
 
   it('rejects an action missing a case', () => {
     const planMissingCase = new ActionPlan({});
-    planMissingCase.action.value = {} as any;
+    planMissingCase.action.value = { something: 'with a value' } as any;
     planMissingCase.action.case = undefined;
 
     expect(() => assertValidActionPlans([planMissingCase], currentUserFullViewingKey)).toThrow(
@@ -44,7 +44,7 @@ describe('individual plans', () => {
 
   it('rejects an action with some unknown case', () => {
     const planUnknownCase = new ActionPlan({});
-    planUnknownCase.action.value = {} as any;
+    planUnknownCase.action.value = { something: 'with a value' } as any;
     planUnknownCase.action.case = 'notValid' as ActionPlan['action']['case'];
     expect(() => assertValidActionPlans([planUnknownCase], currentUserFullViewingKey)).toThrow(
       'Unknown action plan',

--- a/apps/extension/src/state/tx-validation/assert-valid-plan.ts
+++ b/apps/extension/src/state/tx-validation/assert-valid-plan.ts
@@ -122,6 +122,7 @@ export function assertValidActionPlan(
     case 'ics20Withdrawal':
     case 'positionClose':
     case 'positionOpen':
+    case 'positionOpenPlan':
     case 'positionRewardClaim':
     case 'positionWithdraw':
     case 'proposalDepositClaim':

--- a/apps/extension/src/state/tx-validation/assert-valid-plan.ts
+++ b/apps/extension/src/state/tx-validation/assert-valid-plan.ts
@@ -35,12 +35,8 @@ export function assertValidActionPlan(
 ): asserts actionPlan is ActionPlan & { action: { case: string } } {
   const { action } = actionPlan;
 
-  if (action?.value == null) {
-    throw new ReferenceError('Missing action plan', { cause: action });
-  }
-
-  if (!Object.values(action.value).some(v => v != null)) {
-    throw new TypeError('Empty action plan', { cause: action });
+  if (action?.value == null || !Object.values(action.value).some(v => v != null)) {
+    throw new TypeError('Missing action plan', { cause: action });
   }
 
   /* eslint default-case: ["error"] -- explicitly require a default case for handling unexpected input */

--- a/apps/extension/src/state/tx-validation/assert-valid-plan.ts
+++ b/apps/extension/src/state/tx-validation/assert-valid-plan.ts
@@ -1,0 +1,145 @@
+import { AnyMessage, Message, PartialMessage } from '@bufbuild/protobuf';
+import { bech32mAddress } from '@penumbra-zone/bech32m/penumbra';
+import { Address, FullViewingKey } from '@penumbra-zone/protobuf/penumbra/core/keys/v1/keys_pb';
+import { ActionPlan } from '@penumbra-zone/protobuf/penumbra/core/transaction/v1/transaction_pb';
+import { isControlledAddress } from '@penumbra-zone/wasm/address';
+import { Code, ConnectError } from '@connectrpc/connect';
+
+/** guard nonzero inner */
+const hasInner = <M extends Message<M> = AnyMessage>(
+  a?: PartialMessage<M>,
+): a is PartialMessage<M> & { inner: Uint8Array } =>
+  a != null &&
+  'inner' in a &&
+  a.inner instanceof Uint8Array &&
+  !!a.inner.length &&
+  a.inner.some(v => v);
+
+/** Assert specific features for some plans. */
+export function assertValidActionPlans(
+  actions?: PartialMessage<ActionPlan>[],
+  fvk?: PartialMessage<FullViewingKey>,
+): asserts actions is ActionPlan[] {
+  if (!actions?.length) {
+    throw new RangeError('No actions planned', { cause: actions });
+  }
+
+  for (const actionPlan of actions) {
+    assertValidActionPlan(actionPlan, fvk);
+  }
+}
+
+export function assertValidActionPlan(
+  actionPlan: PartialMessage<ActionPlan>,
+  fvk?: PartialMessage<FullViewingKey>,
+): asserts actionPlan is ActionPlan & { action: { case: string } } {
+  const { action } = actionPlan;
+  if (action?.value == null) {
+    throw new ReferenceError('Missing action plan', { cause: action });
+  }
+
+  /* eslint default-case: ["error"] -- explicitly require a default case for handling unexpected input */
+  /* eslint @typescript-eslint/switch-exhaustiveness-check: ["error", { allowDefaultCaseForExhaustiveSwitch: true, considerDefaultExhaustiveForUnions: false }] -- explicitly mention every action type */
+  switch (action.case) {
+    /**
+     * minimal sanity check: output destination address is present and valid
+     * @todo: check if this is correct validation
+     */
+    case 'output':
+      {
+        if (!hasInner(action.value.destAddress)) {
+          throw new ReferenceError('Output action missing destination address');
+        }
+
+        try {
+          bech32mAddress(action.value.destAddress);
+        } catch (invalidAddress) {
+          throw new TypeError('Output action has invalid destination address', { cause: action });
+        }
+      }
+      return;
+
+    /**
+     * swaps are followed by a swapClaim to deliver the outputs. the swap plan
+     * specifies the claim address in advance.
+     *
+     * the swap plan is an external input, created by some frontend dapp.  any
+     * output address may be planned, but most users will probably never want
+     * their swap outputs to be delivered to somebody else.  so the claim
+     * address is inspected to confirm that it's not someone else's address.
+     */
+    case 'swap':
+      {
+        if (!hasInner(action.value.swapPlaintext?.claimAddress)) {
+          throw new ReferenceError('Swap action missing claim address', { cause: action });
+        }
+
+        let bech32mClaimAddress: string;
+        try {
+          bech32mClaimAddress = bech32mAddress(action.value.swapPlaintext.claimAddress);
+        } catch (invalidAddress) {
+          throw new TypeError('Swap action has invalid claim address', { cause: action });
+        }
+
+        if (!hasInner(fvk)) {
+          throw ConnectError.from(
+            new ReferenceError('Full viewing key is required to validate swap action'),
+            Code.Unauthenticated,
+          );
+        }
+
+        if (
+          !isControlledAddress(
+            new FullViewingKey(fvk),
+            new Address(action.value.swapPlaintext.claimAddress),
+          )
+        ) {
+          throw new Error(`Swap action has uncontrolled claim address ${bech32mClaimAddress}`, {
+            cause: action,
+          });
+        }
+      }
+      return;
+
+    /**
+     * for convenience, swapClaims support a unique feature: they may be issued
+     * without authorization by the spend key, because the swap has specified
+     * the claim address in advance.  so, a swapClaim should not be authorized.
+     */
+    case 'swapClaim':
+      throw new TypeError('Swap claim action does not require authorization');
+
+    case 'actionDutchAuctionEnd':
+    case 'actionDutchAuctionSchedule':
+    case 'actionDutchAuctionWithdraw':
+    case 'actionLiquidityTournamentVote':
+    case 'communityPoolDeposit':
+    case 'communityPoolOutput':
+    case 'communityPoolSpend':
+    case 'delegate':
+    case 'delegatorVote':
+    case 'ibcRelayAction':
+    case 'ics20Withdrawal':
+    case 'positionClose':
+    case 'positionOpen':
+    case 'positionRewardClaim':
+    case 'positionWithdraw':
+    case 'proposalDepositClaim':
+    case 'proposalSubmit':
+    case 'proposalWithdraw':
+    case 'spend':
+    case 'undelegate':
+    case 'undelegateClaim':
+    case 'validatorDefinition':
+    case 'validatorVote':
+      // no specific assertions
+      if (!Object.values(action.value).some(v => v != null)) {
+        throw new TypeError('Empty action plan', { cause: action });
+      }
+      return;
+
+    default:
+      action satisfies never;
+      throw new TypeError('Unknown action plan', { cause: action });
+  }
+}

--- a/apps/extension/src/state/tx-validation/assert-valid-plan.ts
+++ b/apps/extension/src/state/tx-validation/assert-valid-plan.ts
@@ -34,8 +34,13 @@ export function assertValidActionPlan(
   fvk?: PartialMessage<FullViewingKey>,
 ): asserts actionPlan is ActionPlan & { action: { case: string } } {
   const { action } = actionPlan;
+
   if (action?.value == null) {
     throw new ReferenceError('Missing action plan', { cause: action });
+  }
+
+  if (!Object.values(action.value).some(v => v != null)) {
+    throw new TypeError('Empty action plan', { cause: action });
   }
 
   /* eslint default-case: ["error"] -- explicitly require a default case for handling unexpected input */
@@ -134,9 +139,6 @@ export function assertValidActionPlan(
     case 'validatorDefinition':
     case 'validatorVote':
       // no specific assertions
-      if (!Object.values(action.value).some(v => v != null)) {
-        throw new TypeError('Empty action plan', { cause: action });
-      }
       return;
 
     default:


### PR DESCRIPTION
instead of performing plan validation inside the custody service before creating UI, perform validation within the approval slice and display validation failures for inspection.