### PR TITLE
fix: content scripts attempt to connect during prerender

### DIFF
--- a/apps/extension/globals.d.ts
+++ b/apps/extension/globals.d.ts
@@ -1,5 +1,19 @@
 declare global {
   /**
+   * Speculation Rules API is available in chrome.  Other browsers don't support
+   * this yet, so it's not in typescript's DOM lib.
+   *
+   * We use the `Document.prerendering` attribute. We also use the
+   * `prerenderingchange` event, but that doesn't need typing.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/Document/prerendering
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/Document/prerenderingchange_event
+   */
+  interface Document {
+    readonly prerendering?: boolean;
+  }
+
+  /**
    * Navigation API is available in chrome.  Other browsers don't support this
    * yet, so it's not in typescript's DOM lib.
    *

--- a/apps/extension/src/content-scripts/message/prerendering.ts
+++ b/apps/extension/src/content-scripts/message/prerendering.ts
@@ -1,0 +1,6 @@
+/** While prerendering, the document isn't a valid sender. */
+export const prerendering = new Promise<void>(resolve =>
+  document.prerendering
+    ? document.addEventListener('prerenderingchange', () => resolve(), { once: true })
+    : resolve(),
+);


### PR DESCRIPTION
speculative navigation may cause content scripts to execute before a document is active. at this point, the document `sender` can't be validated by the requirements of the extension service worker.

this PR uses the document's `prerendering` attribute to detect this state, and the `prerenderingchange` event to detect transition out of this state.