### PR TITLE
reset password: re-encrypt seed phrase after setting new password

### DIFF
--- a/apps/extension/src/routes/popup/settings/settings-reset-password.tsx
+++ b/apps/extension/src/routes/popup/settings/settings-reset-password.tsx
@@ -5,15 +5,17 @@ import { useStore } from '../../../state';
 import { passwordSelector } from '../../../state/password';
 import { SettingsScreen } from './settings-screen';
 import { KeyGradientIcon } from '../../../icons/key-gradient';
+import { walletsSelector } from '../../../state/wallets';
 
 export const SettingsResetPassword = () => {
-  const { isPassword, setPassword: saveNewPassword } = useStore(passwordSelector);
-
   const [currentPassword, setCurrentPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [enteredIncorrect, setEnteredIncorrect] = useState(false);
   const [saved, setSaved] = useState(false);
+  const { isPassword, setPassword } = useStore(passwordSelector);
+  const { reencryptSeedPhrase } = useStore(walletsSelector);
+  const { getSeedPhrase } = useStore(walletsSelector);
 
   const submit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -25,11 +27,14 @@ export const SettingsResetPassword = () => {
         return;
       }
 
-      if (newPassword !== confirmPassword || newPassword.length < 8) {
+      if (newPassword !== confirmPassword) {
         return;
       }
 
-      await saveNewPassword(newPassword);
+      const seedPhrase = await getSeedPhrase();
+      await setPassword(newPassword);
+      await reencryptSeedPhrase(seedPhrase);
+
       setCurrentPassword('');
       setNewPassword('');
       setConfirmPassword('');

--- a/apps/extension/src/routes/popup/settings/settings-reset-password.tsx
+++ b/apps/extension/src/routes/popup/settings/settings-reset-password.tsx
@@ -31,9 +31,9 @@ export const SettingsResetPassword = () => {
         return;
       }
 
-      const seedPhrase = await getSeedPhrase();
-      await setPassword(newPassword);
-      await reencryptSeedPhrase(seedPhrase);
+      const seed = await getSeedPhrase(); // 1. Decrypt with current key
+      await setPassword(newPassword); // 2. Overwrite key (now live in state + session/local)
+      await reencryptSeedPhrase(seed); // 3. Re-encrypt with new key
 
       setCurrentPassword('');
       setNewPassword('');


### PR DESCRIPTION
https://github.com/prax-wallet/prax/pull/361 originally implemented the "reset password" feature, but the implementation was incomplete:

- a new key was derived from the new password and stored as `KeyJson` in memory and session storage,
- the corresponding `KeyPrint` was saved to local storage for future password validation.

However, it _did not_ re-encrypt the existing seed phrase with the new password-derived key after resetting the password. This implementation now does that by (1) decrypting the existing seed using the existing key, (2) setting the new password, and (3) re-encrypting the seed phrase using the new password key. 