### PR TITLE
Use attached popup

### DIFF
--- a/apps/extension/src/hooks/popup-ready.ts
+++ b/apps/extension/src/hooks/popup-ready.ts
@@ -11,15 +11,19 @@ const handlePopup = async <T extends PopupType>(
   // get popup slice acceptRequest method
   const state = useStore.getState();
   const acceptRequest: {
-    [k in PopupType]: (request: PopupRequest<k>[k]) => Promise<PopupResponse<k>[k]>;
+    [k in PopupType]: (
+      request: PopupRequest<k>[k],
+      sender?: chrome.runtime.MessageSender,
+    ) => Promise<PopupResponse<k>[k]>;
   } = {
     [PopupType.TxApproval]: state.txApproval.acceptRequest,
     [PopupType.OriginApproval]: state.originApproval.acceptRequest,
+    [PopupType.LoginPrompt]: state.loginPrompt.acceptRequest,
   };
 
   // handle via slice
   const popupResponse = {
-    [popupType]: await acceptRequest[popupType](popupRequest[popupType]),
+    [popupType]: await acceptRequest[popupType](popupRequest[popupType], popupRequest.sender),
   } as PopupResponse<T>;
 
   return popupResponse;

--- a/apps/extension/src/hooks/use-window-countdown.ts
+++ b/apps/extension/src/hooks/use-window-countdown.ts
@@ -5,9 +5,9 @@ import { useCountdown } from 'usehooks-ts';
  * A hook that counts down each second from a given number only when the window is focused.
  * If the window is out of focus, the countdown will reset and start from the beginning.
  */
-export const useWindowCountdown = () => {
+export const useWindowCountdown = (countStart: number) => {
   const [count, { startCountdown, stopCountdown, resetCountdown }] = useCountdown({
-    countStart: 0.5,
+    countStart,
     countStop: 0,
     intervalMs: 500,
     isIncrement: false,

--- a/apps/extension/src/needs-login.ts
+++ b/apps/extension/src/needs-login.ts
@@ -1,5 +1,7 @@
 import { ConnectError, Code } from '@connectrpc/connect';
 import { sessionExtStorage } from '@repo/storage-chrome/session';
+import { popup } from './popup';
+import { PopupType } from './message/popup';
 
 /** Throws if the user is not logged in. */
 export const throwIfNeedsLogin = async () => {
@@ -7,4 +9,28 @@ export const throwIfNeedsLogin = async () => {
   if (!loggedIn) {
     throw new ConnectError('User must login to extension', Code.Unauthenticated);
   }
+};
+
+/** Prompts the user to login if they are not logged in. */
+export const promptIfNeedsLogin = async (
+  next: Exclude<PopupType, PopupType.LoginPrompt>,
+  sender?: chrome.runtime.MessageSender,
+) => {
+  try {
+    const alreadyLoggedIn = (await sessionExtStorage.get('passwordKey')) != null;
+    if (alreadyLoggedIn) {
+      return;
+    }
+
+    if (sender) {
+      const attemptLogin = await popup(PopupType.LoginPrompt, { next }, sender);
+      if (attemptLogin?.didLogin) {
+        return;
+      }
+    }
+  } catch (failure) {
+    console.error('Failed to log in', failure);
+  }
+
+  throw new ConnectError('User must login to extension', Code.Unauthenticated);
 };

--- a/apps/extension/src/routes/popup/approval/approve-deny.tsx
+++ b/apps/extension/src/routes/popup/approval/approve-deny.tsx
@@ -1,17 +1,18 @@
 import { Button } from '@repo/ui/components/ui/button';
-import { useWindowCountdown } from './use-window-countdown';
+import { useWindowCountdown } from '../../../hooks/use-window-countdown';
 
 export const ApproveDeny = ({
   approve,
   deny,
   ignore,
+  wait,
 }: {
   approve?: () => void;
   deny: () => void;
   ignore?: () => void;
-  wait?: number;
+  wait: number;
 }) => {
-  const count = useWindowCountdown();
+  const count = useWindowCountdown(wait);
 
   return (
     <div
@@ -29,7 +30,7 @@ export const ApproveDeny = ({
         onClick={approve}
         disabled={!approve || count > 0}
       >
-        Approve
+        Approve {count > 0 && `(${count})`}
       </Button>
       <Button
         className='w-1/2 py-3.5 text-base hover:bg-destructive/90'

--- a/apps/extension/src/routes/popup/approval/login-prompt.tsx
+++ b/apps/extension/src/routes/popup/approval/login-prompt.tsx
@@ -1,0 +1,40 @@
+import { useCallback, useMemo } from 'react';
+import { useStore } from '../../../state';
+import { loginPromptSelector } from '../../../state/login-prompt';
+import { Login } from '../login';
+import { PopupType } from '../../../message/popup';
+
+export const LoginPrompt = () => {
+  const { sender, next, sendResponse, setDidLogin } = useStore(loginPromptSelector);
+
+  const onSuccess = useCallback(() => {
+    setDidLogin(true);
+    sendResponse();
+    window.close();
+  }, [sendResponse, setDidLogin]);
+
+  const { reason, detail } = useMemo(() => {
+    switch (next) {
+      case PopupType.TxApproval:
+        return { reason: 'Review transaction request' };
+      case PopupType.OriginApproval:
+        return {
+          reason: 'Review connection request',
+          detail: (
+            <>
+              from{' '}
+              <span className='font-mono'>{sender?.origin && new URL(sender.origin).hostname}</span>
+            </>
+          ),
+        };
+      default:
+        return {};
+    }
+  }, [next, sender]);
+
+  if (!reason) {
+    return null;
+  }
+
+  return <Login onSuccess={onSuccess} message={reason} detail={detail} wait={2} />;
+};

--- a/apps/extension/src/routes/popup/approval/origin.tsx
+++ b/apps/extension/src/routes/popup/approval/origin.tsx
@@ -9,8 +9,7 @@ import { UserChoice } from '@repo/storage-chrome/records';
 import { ExclamationTriangleIcon } from '@radix-ui/react-icons';
 
 export const OriginApproval = () => {
-  const { requestOrigin, favIconUrl, title, lastRequest, setChoice, sendResponse } =
-    useStore(originApprovalSelector);
+  const { sender, lastRequest, setChoice, sendResponse } = useStore(originApprovalSelector);
 
   const approve = () => {
     setChoice(UserChoice.Approved);
@@ -30,7 +29,7 @@ export const OriginApproval = () => {
     window.close();
   };
 
-  if (!requestOrigin) {
+  if (!sender?.origin) {
     return null;
   }
 
@@ -56,7 +55,7 @@ export const OriginApproval = () => {
             >
               <div className='flex flex-col items-center gap-2'>
                 <div className='flex h-11 max-w-full items-center rounded-lg bg-black p-2 text-muted-foreground [z-index:30]'>
-                  {!!favIconUrl && (
+                  {!!sender.tab?.favIconUrl && (
                     <div
                       className={cn(
                         '-ml-3',
@@ -68,15 +67,15 @@ export const OriginApproval = () => {
                       )}
                     >
                       <img
-                        src={favIconUrl}
+                        src={sender.tab.favIconUrl}
                         alt='requesting website icon'
                         className='size-20 min-w-20 rounded-full'
                       />
                     </div>
                   )}
                   <div className='-ml-3 w-full truncate p-2 pl-6 font-headline text-lg'>
-                    {title ? (
-                      <span className='text-primary-foreground'>{title}</span>
+                    {sender.tab?.title?.startsWith(sender.origin) ? (
+                      <span className='text-primary-foreground'>{sender.tab.title}</span>
                     ) : (
                       <span className='text-muted-foreground underline decoration-dotted decoration-2 underline-offset-4'>
                         no title
@@ -86,7 +85,7 @@ export const OriginApproval = () => {
                 </div>
                 <div className='z-30 flex min-h-11 w-full items-center overflow-x-auto rounded-lg bg-background p-2 text-muted-foreground'>
                   <div className='mx-auto items-center p-2 text-center leading-[0.8em]'>
-                    <DisplayOriginURL url={new URL(requestOrigin)} />
+                    <DisplayOriginURL url={new URL(sender.origin)} />
                   </div>
                 </div>
               </div>
@@ -101,7 +100,7 @@ export const OriginApproval = () => {
           </div>
         </div>
         <div className='flex grow flex-col justify-end'>
-          <ApproveDeny approve={approve} deny={deny} ignore={lastRequest && ignore} />
+          <ApproveDeny approve={approve} deny={deny} ignore={lastRequest && ignore} wait={3} />
         </div>
       </div>
     </FadeTransition>

--- a/apps/extension/src/routes/popup/paths.ts
+++ b/apps/extension/src/routes/popup/paths.ts
@@ -1,6 +1,7 @@
 export enum PopupPath {
   INDEX = '/',
   LOGIN = '/login',
+  LOGIN_PROMPT = '/login-prompt',
   TRANSACTION_APPROVAL = '/approval/tx',
   ORIGIN_APPROVAL = '/approval/origin',
   SETTINGS = '/settings',

--- a/apps/extension/src/routes/popup/router.tsx
+++ b/apps/extension/src/routes/popup/router.tsx
@@ -7,6 +7,7 @@ import { Settings } from './settings';
 import { settingsRoutes } from './settings/routes';
 import { TransactionApproval } from './approval/transaction';
 import { OriginApproval } from './approval/origin';
+import { LoginPrompt } from './approval/login-prompt';
 
 export const popupRoutes: RouteObject[] = [
   {
@@ -34,6 +35,10 @@ export const popupRoutes: RouteObject[] = [
       {
         path: PopupPath.ORIGIN_APPROVAL,
         element: <OriginApproval />,
+      },
+      {
+        path: PopupPath.LOGIN_PROMPT,
+        element: <LoginPrompt />,
       },
     ],
   },

--- a/apps/extension/src/senders/approve.test.ts
+++ b/apps/extension/src/senders/approve.test.ts
@@ -3,6 +3,7 @@ import { approveSender } from './approve';
 import { OriginRecord, UserChoice } from '@repo/storage-chrome/records';
 import { PopupType } from '../message/popup';
 import { localExtStorage } from '@repo/storage-chrome/local';
+import { ValidExternalSender } from './external';
 
 const mockPopup = vi.hoisted(() => vi.fn());
 vi.mock('../popup', () => ({
@@ -24,7 +25,10 @@ describe('origin approvals', () => {
 
   describe('approveSender', () => {
     it('prompts and stores choice for a new origin', async () => {
-      const messageSender = { origin: 'mock://unknown.example.com', tab: mockTab };
+      const messageSender = {
+        origin: 'mock://unknown.example.com',
+        tab: mockTab,
+      } as ValidExternalSender;
 
       const newOriginRecord: OriginRecord = {
         choice: UserChoice.Approved,
@@ -44,7 +48,10 @@ describe('origin approvals', () => {
       await localExtStorage.set('knownSites', [
         { origin: 'mock://ignored.example.com', choice: UserChoice.Ignored, date: 123 },
       ]);
-      const messageSender = { origin: 'mock://ignored.example.com', tab: mockTab };
+      const messageSender = {
+        origin: 'mock://ignored.example.com',
+        tab: mockTab,
+      } as ValidExternalSender;
 
       const choice = await approveSender(messageSender);
       expect(choice).toBe(UserChoice.Ignored);
@@ -56,7 +63,10 @@ describe('origin approvals', () => {
         { origin: 'mock://duplicate.example.com', choice: UserChoice.Denied, date: 123 },
       ]);
 
-      const messageSender = { origin: 'mock://duplicate.example.com', tab: mockTab };
+      const messageSender = {
+        origin: 'mock://duplicate.example.com',
+        tab: mockTab,
+      } as ValidExternalSender;
       await expect(approveSender(messageSender)).rejects.toThrow(
         'There are multiple records for origin',
       );
@@ -64,7 +74,10 @@ describe('origin approvals', () => {
 
     it('returns denied choice if the popup is closed without a choice', async () => {
       await localExtStorage.set('knownSites', []);
-      const messageSender = { origin: 'mock://unknown.example.com', tab: mockTab };
+      const messageSender = {
+        origin: 'mock://unknown.example.com',
+        tab: mockTab,
+      } as ValidExternalSender;
       mockPopup.mockResolvedValue(undefined);
 
       const choice = await approveSender(messageSender);
@@ -73,7 +86,10 @@ describe('origin approvals', () => {
 
     it('returns denied choice if the popup is denied', async () => {
       await localExtStorage.set('knownSites', []);
-      const messageSender = { origin: 'mock://unknown.example.com', tab: mockTab };
+      const messageSender = {
+        origin: 'mock://unknown.example.com',
+        tab: mockTab,
+      } as ValidExternalSender;
       mockPopup.mockResolvedValue({
         choice: UserChoice.Denied,
         date: 123,
@@ -88,7 +104,10 @@ describe('origin approvals', () => {
       await localExtStorage.set('knownSites', [
         { origin: 'mock://upsertable.example.com', choice: UserChoice.Denied, date: 123 },
       ]);
-      const messageSender = { origin: 'mock://upsertable.example.com', tab: mockTab };
+      const messageSender = {
+        origin: 'mock://upsertable.example.com',
+        tab: mockTab,
+      } as ValidExternalSender;
 
       const newOriginRecord = {
         choice: UserChoice.Approved,
@@ -105,7 +124,10 @@ describe('origin approvals', () => {
 
     it('calls popup with the correct parameters', async () => {
       await localExtStorage.set('knownSites', []);
-      const messageSender = { origin: 'mock://popuptest.example.com', tab: mockTab };
+      const messageSender = {
+        origin: 'mock://popuptest.example.com',
+        tab: mockTab,
+      } as ValidExternalSender;
       mockPopup.mockResolvedValue({
         choice: UserChoice.Approved,
         date: 123,
@@ -114,12 +136,11 @@ describe('origin approvals', () => {
 
       await approveSender(messageSender);
 
-      expect(mockPopup).toHaveBeenCalledWith(PopupType.OriginApproval, {
-        origin: 'mock://popuptest.example.com',
-        favIconUrl: mockTab.favIconUrl,
-        title: mockTab.title,
-        lastRequest: undefined,
-      });
+      expect(mockPopup).toHaveBeenCalledWith(
+        PopupType.OriginApproval,
+        { lastRequest: undefined },
+        messageSender,
+      );
     });
 
     it('persists known sites when a new site is added', async () => {
@@ -130,7 +151,10 @@ describe('origin approvals', () => {
       } satisfies OriginRecord;
       await localExtStorage.set('knownSites', [existingOriginRecord]);
 
-      const messageSender = { origin: 'mock://unknown.example.com', tab: mockTab };
+      const messageSender = {
+        origin: 'mock://unknown.example.com',
+        tab: mockTab,
+      } as ValidExternalSender;
       const newOriginRecord = {
         choice: UserChoice.Approved,
         date: 123,

--- a/apps/extension/src/state/index.ts
+++ b/apps/extension/src/state/index.ts
@@ -13,6 +13,7 @@ import { createOriginApprovalSlice, OriginApprovalSlice } from './origin-approva
 import { ConnectedSitesSlice, createConnectedSitesSlice } from './connected-sites';
 import { createDefaultFrontendSlice, DefaultFrontendSlice } from './default-frontend';
 import { createNumerairesSlice, NumerairesSlice } from './numeraires';
+import { createLoginPromptSlice, LoginPromptSlice } from './login-prompt';
 
 export interface AllSlices {
   wallets: WalletsSlice;
@@ -24,6 +25,7 @@ export interface AllSlices {
   originApproval: OriginApprovalSlice;
   connectedSites: ConnectedSitesSlice;
   defaultFrontend: DefaultFrontendSlice;
+  loginPrompt: LoginPromptSlice;
 }
 
 export type SliceCreator<SliceInterface> = StateCreator<
@@ -47,6 +49,7 @@ export const initializeStore = (
     txApproval: createTxApprovalSlice(local)(setState, getState, store),
     originApproval: createOriginApprovalSlice()(setState, getState, store),
     defaultFrontend: createDefaultFrontendSlice(local)(setState, getState, store),
+    loginPrompt: createLoginPromptSlice()(setState, getState, store),
   }));
 };
 

--- a/apps/extension/src/state/login-prompt.ts
+++ b/apps/extension/src/state/login-prompt.ts
@@ -1,0 +1,79 @@
+import type { AllSlices, SliceCreator } from '.';
+import type { PopupRequest, PopupResponse, PopupType } from '../message/popup';
+
+export interface LoginPromptSlice {
+  responder?: PromiseWithResolvers<PopupResponse<PopupType.LoginPrompt>[PopupType.LoginPrompt]>;
+  next?: Exclude<PopupType, PopupType.LoginPrompt>;
+  sender?: chrome.runtime.MessageSender;
+  didLogin?: boolean;
+
+  acceptRequest: (
+    req: PopupRequest<PopupType.LoginPrompt>[PopupType.LoginPrompt],
+    sender?: chrome.runtime.MessageSender,
+  ) => Promise<PopupResponse<PopupType.LoginPrompt>[PopupType.LoginPrompt]>;
+
+  setDidLogin: (didLogin: boolean) => void;
+
+  sendResponse: () => void;
+}
+
+export const createLoginPromptSlice = (): SliceCreator<LoginPromptSlice> => (set, get) => {
+  const cleanup = () => {
+    set(state => {
+      state.loginPrompt.responder = undefined;
+      state.loginPrompt.sender = undefined;
+      state.loginPrompt.next = undefined;
+      state.loginPrompt.didLogin = undefined;
+    });
+  };
+
+  return {
+    acceptRequest: ({ next }, sender) => {
+      const existing = get().loginPrompt;
+      if (existing.responder) {
+        throw new Error('Another request is still pending');
+      }
+      if (!sender) {
+        throw new ReferenceError('No sender');
+      }
+
+      const responder =
+        Promise.withResolvers<PopupResponse<PopupType.LoginPrompt>[PopupType.LoginPrompt]>();
+
+      set(state => {
+        state.loginPrompt.responder = responder;
+        state.loginPrompt.sender = sender;
+        state.loginPrompt.next = next;
+      });
+
+      return responder.promise.finally(cleanup);
+    },
+
+    setDidLogin: didLogin => {
+      set(state => {
+        state.loginPrompt.didLogin = didLogin;
+      });
+    },
+
+    sendResponse: () => {
+      const { responder, next, sender, didLogin } = get().loginPrompt;
+
+      if (!responder) {
+        cleanup();
+        throw new ReferenceError('No responder');
+      }
+
+      try {
+        if (!sender || !next || didLogin == null) {
+          throw new ReferenceError('Missing request data');
+        }
+
+        responder.resolve({ didLogin });
+      } catch (e) {
+        responder.reject(e);
+      }
+    },
+  };
+};
+
+export const loginPromptSelector = (state: AllSlices) => state.loginPrompt;


### PR DESCRIPTION
Refactors popup handling to use attached popups instead of creating new windows where feasible. This improves the user experience by keeping approval dialogs contextually connected to the originating tab.

The transaction approval popup still does not appear attached, due to the lack of sender information at the call site.

## Changes

- Moved countdown hook to shared location for reuse across components
- Added login prompt state management and routing
- Updated approval flows to use sender context for popup attachment
- Fixed test mocking to use current storage patterns instead of deprecated manual mocks
