### PR TITLE
Release preview zip

### DIFF
--- a/.github/workflows/extension-upload.yml
+++ b/.github/workflows/extension-upload.yml
@@ -53,7 +53,7 @@ jobs:
           body: |
             Unsigned build of Prax wallet BETA ${{ github.ref_name }} as
             uploaded to the Chrome Web Store.
-            
+
             This build is intended for developers and is not suitable for use
             outside of a testnet environment.
           files: |


### PR DESCRIPTION
presently, prax does not publish release artifacts on github.

edited: this PR will simply publish the beta zip as a github release, without any signature.