### PR TITLE
prep v19.2.0

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chrome-extension",
-  "version": "19.1.0",
+  "version": "19.2.0",
   "private": true,
   "license": "(MIT OR Apache-2.0)",
   "description": "chrome-extension",

--- a/apps/extension/public/beta-manifest.json
+++ b/apps/extension/public/beta-manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Prax wallet BETA",
-  "version": "19.1.0",
+  "version": "19.2.0",
   "description": "THIS EXTENSION IS FOR BETA TESTING",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAhxDXNrlRB72kw+MeeofiBvJuuSkcMI+ZshYS9jve+Zhm0YlYUF/3mriz1D7jdK/U11EjKYMYCTQQEDLmSdQ8Q52ur3ei4u4gjyEpl/+QnjciR7msoziKH48Bia1U+wd53eW3TWNP/vpSJiBsAfOisEPox6w4lC5a03aCXV3xtkzfW0rebZrOLf1xhZD8mc4N9LU289E3cYRlBmfI4qxkBM1r7t9N4KsXle3VWXSn18joKzgzAWK+VhZtZu3xrwMQGpUqn+KyYFvawSGmYdDsnT6y0KS96V3CPp6rQHNfjItB/F4d1JQv1tskc959jiK9CuGbU57D9JHJ+1C9aOb0BwIDAQAB",
   "minimum_chrome_version": "119",

--- a/apps/extension/public/manifest.json
+++ b/apps/extension/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Prax wallet",
-  "version": "19.1.0",
+  "version": "19.2.0",
   "description": "For use in interacting with the Penumbra blockchain",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvnucOJi878TGZYnTNTrvXd9krAcpSDR/EgHcQhvjNZrKfRRsKA9O0DnbyM492c3hiicYPevRPLPoKsLgVghGDYPr8eNO7ee165keD5XLxq0wpWu14gHEPdQSRNZPLeawLp4s/rUwtzMcxhVIUYYaa2xZri4Tqx9wpR7YR1mQTAL8UsdjyitrnzTM20ciKXq1pd82MU74YaZzrcQCOmcjJtjHFdMEAYme+LuZuEugAgef9RiE/8kLQ6T7W9feYfQOky1OPjBkflpRXRgW6cACdl+MeYhKJCOHijglFsPOXX6AvnoJSeAJYRXOMVJi0ejLKEcrLpaeHgh+1WXUvc5G4wIDAQAB",
   "minimum_chrome_version": "119",

--- a/apps/extension/src/routes/page/onboarding/constants.ts
+++ b/apps/extension/src/routes/page/onboarding/constants.ts
@@ -6,6 +6,3 @@ export const DEFAULT_GRPC = 'https://penumbra-1.radiantcommons.com';
 
 // Define a canonical default frontend.
 export const DEFAULT_FRONTEND = 'https://dex.penumbra.zone';
-
-// Define a canonical default landing page.
-export const DEFAULT_LANDING_PAGE = 'https://praxwallet.com/welcome';

--- a/apps/extension/src/routes/page/onboarding/success.tsx
+++ b/apps/extension/src/routes/page/onboarding/success.tsx
@@ -1,16 +1,18 @@
 import { useEffect, useRef } from 'react';
-import { DEFAULT_LANDING_PAGE } from './constants';
+import { useStore } from '../../../state';
+import { getDefaultFrontend } from '../../../state/default-frontend';
 
 export const OnboardingSuccess = () => {
+  const defaultFrontendUrl = useStore(getDefaultFrontend);
   const hasOpened = useRef(false);
 
   useEffect(() => {
-    if (!hasOpened.current) {
+    if (!hasOpened.current && defaultFrontendUrl) {
       hasOpened.current = true;
-      window.open(DEFAULT_LANDING_PAGE, '_blank');
+      window.open(defaultFrontendUrl, '_blank');
       window.close();
     }
-  }, [DEFAULT_LANDING_PAGE]);
+  }, [defaultFrontendUrl]);
 
   return null;
 };


### PR DESCRIPTION
reverts https://github.com/prax-wallet/prax/pull/364 and bumps manifest versions to `v19.2.0`.