### PR TITLE
 Correct storage mock set behavior

### DIFF
--- a/apps/extension/src/ctx/spend-key.test.ts
+++ b/apps/extension/src/ctx/spend-key.test.ts
@@ -70,7 +70,7 @@ describe('Authorize request handler', () => {
   });
 
   test('should fail if user is not logged in extension', async () => {
-    await sessionExtStorage.set('passwordKey', undefined);
+    await sessionExtStorage.remove('passwordKey');
     await expect(getSpendKey()).rejects.toThrow('User must login');
   });
 

--- a/packages/storage-chrome/src/base.ts
+++ b/packages/storage-chrome/src/base.ts
@@ -9,6 +9,7 @@ export interface IStorage {
   getBytesInUse(keys?: string | string[] | null): Promise<number>;
   set(items: Record<string, unknown>): Promise<void>;
   remove(key: string): Promise<void>;
+  clear(): Promise<void>;
   onChanged: {
     addListener(listener: Listener): void;
     removeListener(listener: Listener): void;
@@ -183,6 +184,10 @@ export class ExtensionStorage<T extends { dbVersion: number }> {
     // Migrations save the database intermediate states hard to type
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- EXISTING USE
     const nextState = await migrationFn(currentDbState);
+
+    // Clean old data
+    await this.storage.clear();
+
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- EXISTING USE
     await this._set(nextState);
 

--- a/packages/storage-chrome/src/mock.ts
+++ b/packages/storage-chrome/src/mock.ts
@@ -54,11 +54,10 @@ export class MockStorageArea implements IStorage {
   async set(items: Record<string, unknown>): Promise<void> {
     return new Promise(resolve => {
       for (const key in items) {
-        // In chrome storage, setting undefined values removes them from the store
-        if (items[key] === undefined) {
-          this.store.delete(key);
+        // In chrome storage, setting undefined values is a no-op
+        if (items[key] !== undefined) {
+          this.store.set(key, items[key]);
         }
-        this.store.set(key, items[key]);
       }
       resolve();
     });

--- a/packages/storage-chrome/src/mock.ts
+++ b/packages/storage-chrome/src/mock.ts
@@ -63,6 +63,13 @@ export class MockStorageArea implements IStorage {
     });
   }
 
+  async clear(): Promise<void> {
+    return new Promise(resolve => {
+      this.store.clear();
+      resolve();
+    });
+  }
+
   onChanged = {
     addListener() {
       // no-op


### PR DESCRIPTION
reopens #372

fixes https://github.com/prax-wallet/prax/issues/371

one test which relied upon the set-undefined behavior is updated to use `remove`.

to correct behavior without extensively modifying migrations, the migration utility now clears the entire storage before committing the migrated data.

after review of historical versions which may experience migration conflicts, i don't think they will attempt to write to storage, so this is safe.