### PR TITLE
ci: don't create draft release objects

### DIFF
--- a/.github/workflows/extension-upload.yml
+++ b/.github/workflows/extension-upload.yml
@@ -43,22 +43,6 @@ jobs:
       - name: Zip extension versions
         run: pnpm zip
 
-      - name: Draft preview release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ github.ref_name }}
-          name: Prax wallet BETA Developer Preview
-          draft: true
-          prerelease: true
-          body: |
-            Unsigned build of Prax wallet BETA ${{ github.ref_name }} as
-            uploaded to the Chrome Web Store.
-
-            This build is intended for developers and is not suitable for use
-            outside of a testnet environment.
-          files: |
-            beta.zip:Prax.wallet.BETA.Developer.Preview.${{ github.ref_name }}.zip
-
       - name: Upload beta version
         uses: prax-wallet/chrome-extension-upload@v1
         with:


### PR DESCRIPTION
Partial reversion of 5b01bf98bf9e74eb421bb8b829148cdbdfe7c7df, from PR #378. Keeps the relocated GHA references, drops the draft release object, as we prefer the old-style changelogs.

## Screenshot of draft release object
![gh-release](https://github.com/user-attachments/assets/b75216f0-e7eb-4e9a-81fd-f5c330df688d)

## Here's that same release object edited:

![release-final](https://github.com/user-attachments/assets/aa216d54-c543-4e7a-acfb-2496f5afc5e1)
