### PR TITLE
Clean up storage/zustand persist

### DIFF
--- a/apps/extension/src/state/index.ts
+++ b/apps/extension/src/state/index.ts
@@ -39,7 +39,7 @@ export const initializeStore = (
   local: ExtensionStorage<LocalStorageState>,
 ) => {
   return immer((setState, getState: () => AllSlices, store) => ({
-    wallets: createWalletsSlice(local)(setState, getState, store),
+    wallets: createWalletsSlice(session, local)(setState, getState, store),
     password: createPasswordSlice(session, local)(setState, getState, store),
     seedPhrase: createSeedPhraseSlice(setState, getState, store),
     network: createNetworkSlice(local)(setState, getState, store),

--- a/apps/extension/src/state/password.test.ts
+++ b/apps/extension/src/state/password.test.ts
@@ -51,10 +51,6 @@ describe('Password Slice', () => {
     expect(await useStore.getState().password.isPassword('wrong password')).toBeFalsy();
   });
 
-  test('password key is initially undefined', () => {
-    expect(useStore.getState().password.key).toBeUndefined();
-  });
-
   test('password key can be set to session storage', async () => {
     await useStore.getState().password.setPassword(password);
     await useStore.getState().wallets.addWallet({

--- a/apps/extension/src/state/persist.ts
+++ b/apps/extension/src/state/persist.ts
@@ -3,8 +3,7 @@ import { AllSlices } from '.';
 import { produce } from 'immer';
 
 import { localExtStorage } from '@repo/storage-chrome/local';
-import { LocalStorageState, OriginRecord } from '@repo/storage-chrome/types';
-import { sessionExtStorage, SessionStorageState } from '@repo/storage-chrome/session';
+import { OriginRecord } from '@repo/storage-chrome/origin';
 import { walletsFromJson } from '@penumbra-zone/types/wallet';
 import { AppParameters } from '@penumbra-zone/protobuf/penumbra/core/app/v1/app_pb';
 
@@ -18,129 +17,95 @@ export type Middleware = <
 
 type Persist = (f: StateCreator<AllSlices>) => StateCreator<AllSlices>;
 
-type Setter = (
-  partial: (state: AllSlices) => Partial<AllSlices> | AllSlices,
-  replace?: boolean | undefined,
-) => void;
-
 export const customPersistImpl: Persist = f => (set, get, store) => {
   void (async function () {
     // Part 1: Get storage values and sync them to store
-    const passwordKey = await sessionExtStorage.get('passwordKey');
     const wallets = await localExtStorage.get('wallets');
     const grpcEndpoint = await localExtStorage.get('grpcEndpoint');
-    const knownSites = (await localExtStorage.get('knownSites')) as OriginRecord[];
+    const knownSites = await localExtStorage.get('knownSites');
     const frontendUrl = await localExtStorage.get('frontendUrl');
     const numeraires = await localExtStorage.get('numeraires');
 
     set(
       produce((state: AllSlices) => {
-        state.password.key = passwordKey;
         state.wallets.all = walletsFromJson(wallets);
         state.network.grpcEndpoint = grpcEndpoint;
-        state.connectedSites.knownSites = knownSites;
+        state.connectedSites.knownSites = knownSites as OriginRecord[];
         state.defaultFrontend.url = frontendUrl;
         state.numeraires.selectedNumeraires = numeraires;
       }),
     );
 
     // Part 2: when chrome.storage changes sync select fields to store
-    chrome.storage.onChanged.addListener((changes, area) => {
-      if (area === 'local') {
-        syncLocal(changes, set);
+    localExtStorage.addListener(changes => {
+      if (changes.wallets) {
+        const wallets = changes.wallets.newValue;
+        set(
+          produce((state: AllSlices) => {
+            state.wallets.all = walletsFromJson(wallets ?? []);
+          }),
+        );
       }
-      if (area === 'session') {
-        syncSession(changes, set);
+
+      if (changes.fullSyncHeight) {
+        const stored = changes.fullSyncHeight.newValue;
+        set(
+          produce((state: AllSlices) => {
+            state.network.fullSyncHeight = stored ?? 0;
+          }),
+        );
+      }
+
+      if (changes.grpcEndpoint) {
+        const stored = changes.grpcEndpoint.newValue;
+        set(
+          produce((state: AllSlices) => {
+            state.network.grpcEndpoint = stored ?? state.network.grpcEndpoint;
+          }),
+        );
+      }
+
+      if (changes.knownSites) {
+        const stored = changes.knownSites.newValue as OriginRecord[] | undefined;
+        set(
+          produce((state: AllSlices) => {
+            state.connectedSites.knownSites = stored ?? state.connectedSites.knownSites;
+          }),
+        );
+      }
+
+      if (changes.frontendUrl) {
+        const stored = changes.frontendUrl.newValue;
+        set(
+          produce((state: AllSlices) => {
+            state.defaultFrontend.url = stored ?? state.defaultFrontend.url;
+          }),
+        );
+      }
+
+      if (changes.numeraires) {
+        const stored = changes.numeraires.newValue;
+        set(
+          produce((state: AllSlices) => {
+            state.numeraires.selectedNumeraires = stored ?? state.numeraires.selectedNumeraires;
+          }),
+        );
+      }
+
+      if (changes.params) {
+        const stored = changes.params.newValue;
+        set(
+          produce((state: AllSlices) => {
+            state.network.chainId = stored
+              ? AppParameters.fromJsonString(stored).chainId
+              : state.network.chainId;
+          }),
+        );
       }
     });
   })();
 
   return f(set, get, store);
 };
-
-function syncLocal(changes: Record<string, chrome.storage.StorageChange>, set: Setter) {
-  if (changes['wallets']) {
-    const wallets = changes['wallets'].newValue as LocalStorageState['wallets'] | undefined;
-    set(
-      produce((state: AllSlices) => {
-        state.wallets.all = wallets ? walletsFromJson(wallets) : [];
-      }),
-    );
-  }
-
-  if (changes['fullSyncHeight']) {
-    const stored = changes['fullSyncHeight'].newValue as
-      | LocalStorageState['fullSyncHeight']
-      | undefined;
-    set(
-      produce((state: AllSlices) => {
-        state.network.fullSyncHeight = stored ?? 0;
-      }),
-    );
-  }
-
-  if (changes['grpcEndpoint']) {
-    const stored = changes['grpcEndpoint'].newValue as
-      | LocalStorageState['grpcEndpoint']
-      | undefined;
-    set(
-      produce((state: AllSlices) => {
-        state.network.grpcEndpoint = stored ?? state.network.grpcEndpoint;
-      }),
-    );
-  }
-
-  if (changes['knownSites']) {
-    const stored = changes['knownSites'].newValue as LocalStorageState['knownSites'] | undefined;
-    set(
-      produce((state: AllSlices) => {
-        state.connectedSites.knownSites =
-          (stored as OriginRecord[] | undefined) ?? state.connectedSites.knownSites;
-      }),
-    );
-  }
-
-  if (changes['frontendUrl']) {
-    const stored = changes['frontendUrl'].newValue as LocalStorageState['frontendUrl'] | undefined;
-    set(
-      produce((state: AllSlices) => {
-        state.defaultFrontend.url = stored ?? state.defaultFrontend.url;
-      }),
-    );
-  }
-
-  if (changes['numeraires']) {
-    const stored = changes['numeraires'].newValue as LocalStorageState['numeraires'] | undefined;
-    set(
-      produce((state: AllSlices) => {
-        state.numeraires.selectedNumeraires = stored ?? state.numeraires.selectedNumeraires;
-      }),
-    );
-  }
-
-  if (changes['params']) {
-    const stored = changes['params'].newValue as LocalStorageState['params'] | undefined;
-    set(
-      produce((state: AllSlices) => {
-        state.network.chainId = stored
-          ? AppParameters.fromJsonString(stored).chainId
-          : state.network.chainId;
-      }),
-    );
-  }
-}
-
-function syncSession(changes: Record<string, chrome.storage.StorageChange>, set: Setter) {
-  if (changes['hashedPassword']) {
-    const item = changes['hashedPassword'].newValue as
-      | SessionStorageState['passwordKey']
-      | undefined;
-    set(
-      produce((state: AllSlices) => {
-        state.password.key = item ? item : undefined;
-      }),
-    );
-  }
-}
 
 export const customPersist = customPersistImpl as Middleware;

--- a/apps/extension/src/state/wallets.ts
+++ b/apps/extension/src/state/wallets.ts
@@ -2,7 +2,7 @@ import { Key } from '@penumbra-zone/crypto-web/encryption';
 import { Wallet, WalletCreate } from '@penumbra-zone/types/wallet';
 import { generateSpendKey, getFullViewingKey, getWalletId } from '@penumbra-zone/wasm/keys';
 import { ExtensionStorage } from '@repo/storage-chrome/base';
-import { LocalStorageState } from '@repo/storage-chrome/types';
+import { LocalStorageState, SessionStorageState } from '@repo/storage-chrome/types';
 import { AllSlices, SliceCreator } from '.';
 
 export interface WalletsSlice {
@@ -12,7 +12,10 @@ export interface WalletsSlice {
 }
 
 export const createWalletsSlice =
-  (local: ExtensionStorage<LocalStorageState>): SliceCreator<WalletsSlice> =>
+  (
+    session: ExtensionStorage<SessionStorageState>,
+    local: ExtensionStorage<LocalStorageState>,
+  ): SliceCreator<WalletsSlice> =>
   (set, get) => {
     return {
       all: [],
@@ -21,7 +24,7 @@ export const createWalletsSlice =
         const spendKey = generateSpendKey(seedPhraseStr);
         const fullViewingKey = getFullViewingKey(spendKey);
 
-        const passwordKey = get().password.key;
+        const passwordKey = await session.get('passwordKey');
         if (passwordKey === undefined) {
           throw new Error('Password Key not in storage');
         }
@@ -45,7 +48,7 @@ export const createWalletsSlice =
         return newWallet;
       },
       getSeedPhrase: async () => {
-        const passwordKey = get().password.key;
+        const passwordKey = await session.get('passwordKey');
         if (!passwordKey) {
           throw new Error('no password set');
         }


### PR DESCRIPTION
zustand persist is slightly broken, with some misnamed keys

just drop the session persist, which never worked. use the typed listener provided by `ExtensionStorage` wrapper.

drop unused password key from zustand.

this is split out from https://github.com/prax-wallet/prax/pull/390