### PR TITLE
Increase genesis chunking policy

### DIFF
--- a/packages/query/src/block-processor.ts
+++ b/packages/query/src/block-processor.ts
@@ -179,7 +179,7 @@ export class BlockProcessor implements BlockProcessorInterface {
     // inside a compact block (~100KB). We don't neccessarily need to determine the optimal chunk
     // size, rather it needs to be sufficiently small that devices can handle crossing the syncing
     // hurdle of processing the genesis block.
-    const GENESIS_CHUNK_SIZE = 500;
+    const GENESIS_CHUNK_SIZE = 2000;
 
     // start at next block, or genesis if height is undefined
     const fullSyncHeight = await this.indexedDb.getFullSyncHeight();


### PR DESCRIPTION
https://github.com/prax-wallet/prax/pull/257 introduced chunked genesis sync with a chunking policy of 500 SNRs. Through empirical testing, i've found that on particularly slow wifi connections the genesis sync often fails to complete unless you keep the extension open, possibly due to the increased frequency of wasm boundary crossings between chunking passes. Increasing the chunking policy to 2K SNRs maintains the benefits of chunking for lower-powered devices while also allowing the sync to complete reliably, even on slower connections.

references https://github.com/penumbra-zone/web/issues/2640